### PR TITLE
Removes checks for unknown API keys

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -178,28 +178,6 @@ func (p *singlestoreProvider) ValidateConfig(ctx context.Context, req provider.V
 		return
 	}
 
-	if conf.APIKey.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root(config.APIKeyAttribute),
-			"Unknown API key",
-			"The provider cannot create the Management API client as there is an unknown configuration value for the API key. "+
-				config.InvalidAPIKeyErrorDetail,
-		)
-
-		return
-	}
-
-	if conf.APIKeyPath.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root(config.APIKeyPathAttribute),
-			"Unknown API key path",
-			"The provider cannot create the Management API client as there is an unknown configuration value for the API key path. "+
-				config.InvalidAPIKeyErrorDetail,
-		)
-
-		return
-	}
-
 	if conf.APIServiceURL.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root(config.APIServiceURLAttribute),


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18B4xzIxOSFaXSJ9CgMOAG8BmZPPLn02y4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=yimPIZW)
Unknown values occur when API keys are read from other resources in Terraform, e.g. AWS secrets manager so these checks block such dependency setups.

Bad or missing API keys are still caught and handled when the API is called.


Example Terraform used to test/confirm this behaviour:


```HCL
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 4.0"
    }
    singlestoredb = {
      source  = "singlestore-labs/singlestoredb"
      version = "0.1.0-alpha.3"
    }
  }
}

locals {
  api_key = jsondecode(data.aws_secretsmanager_secret_version.singlestore_api_key.secret_string)
}

provider "aws" {
  region = "eu-west-2"
  profile = terraform.workspace
}

provider "singlestoredb" {
  api_key = local.api_key.bad_api_key
}

resource "aws_secretsmanager_secret" "singlestore_api_key" {
  name = "singlestore_api_key_rn_test"
}

data "aws_secretsmanager_secret_version" "singlestore_api_key" {
  secret_id = aws_secretsmanager_secret.singlestore_api_key.id
}

resource "singlestoredb_workspace_group" "workspace_group" {
  name            = "rn_test"
  firewall_ranges = ["0.0.0.0/0"] // Ensure restrictive ranges for production environments.
  region_id       = "04eb4250-5417-4300-9822-70cf4f114543" # eu-west-2
}
```
