### PR TITLE
Not running integration tests on MRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,9 +6,6 @@ on:
       - master
   schedule:
     - cron: '0 1 * * *'
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.

Therefore, we cannot both accept PRs like https://github.com/singlestore-labs/terraform-provider-singlestoredb/pull/13 and keep the secret safe.

After the change, integration tests will still be automatically run on pushing to master and daily.

https://github.com/orgs/community/discussions/50161