### PR TITLE
Unit tests for the testutil package

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - internal/provider/testutil/testutil.go

--- a/internal/provider/config/const.go
+++ b/internal/provider/config/const.go
@@ -71,6 +71,12 @@ const (
 	// TestWorkspaceGroupExpiration is the time after which a workspace group auto-terminates.
 	// This is an extra safeguard to cleanup resources after running integration tests.
 	TestWorkspaceGroupExpiration = 2 * time.Hour
+	// ResourceTypeName is a type name for accessing resource objects in *.tf files. The other types are data source and provider.
+	ResourceTypeName = "resource"
+	// DataSourceTypeName is a type name for accessing data source objects in *.tf files. The other types are resource and provider.
+	DataSourceTypeName = "data"
+	// ProviderTypeName is a type name for accessing provider objects in *.tf files. The other types are resource and data source.
+	ProviderTypeName = "provider"
 )
 
 var (

--- a/internal/provider/testutil/testutil.go
+++ b/internal/provider/testutil/testutil.go
@@ -184,11 +184,3 @@ func CreateTemp(body string) (string, func(), error) {
 
 	return f.Name(), clean, nil
 }
-
-func resourceTypeName(name string) string {
-	return strings.Join([]string{config.ProviderName, name}, "_")
-}
-
-func dataSourceTypeName(name string) string {
-	return strings.Join([]string{config.ProviderName, name}, "_")
-}

--- a/internal/provider/testutil/updatableconfig.go
+++ b/internal/provider/testutil/updatableconfig.go
@@ -1,6 +1,9 @@
 package testutil
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
@@ -9,105 +12,31 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// UpdatableConfig is the convenience for updating the config example for tests.
+// UpdatableConfig is the convenience for updating the config *.tf examples.
+// This enables overriding values like an API key of the provider for testing purposes.
 type UpdatableConfig string
 
 // AttributeSetter is a type for setting an hcl attribute for a provider, data source, or resource.
 type AttributeSetter func(name string, val cty.Value) UpdatableConfig
 
-func (uc UpdatableConfig) WithWorkspaceGroupGetDataSoure(workspaceGroupName string) AttributeSetter {
-	return func(attributeName string, val cty.Value) UpdatableConfig {
-		file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-		if diags.HasErrors() {
-			panic(diags)
-		}
-
-		workspaceGroup := file.Body().FirstMatchingBlock("data", []string{
-			dataSourceTypeName(workspacegroups.DataSourceGetName), workspaceGroupName,
-		})
-		if workspaceGroup == nil {
-			panic("config file should contain a block with the workspace group data source to add or update an attribute")
-		}
-		_ = workspaceGroup.Body().SetAttributeValue(attributeName, val)
-
-		return UpdatableConfig(file.Bytes())
-	}
+func (uc UpdatableConfig) WithWorkspaceGroupGetDataSource(workspaceGroupName string) AttributeSetter {
+	return withAttribute(uc, config.DataSourceTypeName, []string{dataSourceTypeName(workspacegroups.DataSourceGetName), workspaceGroupName})
 }
 
 func (uc UpdatableConfig) WithWorkspaceGetDataSource(workspaceName string) AttributeSetter {
-	return func(attributeName string, val cty.Value) UpdatableConfig {
-		file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-		if diags.HasErrors() {
-			panic(diags)
-		}
-
-		workspace := file.Body().FirstMatchingBlock("data", []string{
-			dataSourceTypeName(workspaces.DataSourceGetName), workspaceName,
-		})
-		if workspace == nil {
-			panic("config file should contain a block with the workspace data source to add or update an attribute")
-		}
-		_ = workspace.Body().SetAttributeValue(attributeName, val)
-
-		return UpdatableConfig(file.Bytes())
-	}
+	return withAttribute(uc, config.DataSourceTypeName, []string{dataSourceTypeName(workspaces.DataSourceGetName), workspaceName})
 }
 
-func (uc UpdatableConfig) WithWorkspaceListDataSoure(workspaceListName string) AttributeSetter {
-	return func(attributeName string, val cty.Value) UpdatableConfig {
-		file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-		if diags.HasErrors() {
-			panic(diags)
-		}
-
-		workspaceList := file.Body().FirstMatchingBlock("data", []string{
-			dataSourceTypeName(workspaces.DataSourceListName), workspaceListName,
-		})
-		if workspaceList == nil {
-			panic("config file should contain a block with the workspace list data source to add or update an attribute")
-		}
-		_ = workspaceList.Body().SetAttributeValue(attributeName, val)
-
-		return UpdatableConfig(file.Bytes())
-	}
+func (uc UpdatableConfig) WithWorkspaceListDataSource(workspaceListName string) AttributeSetter {
+	return withAttribute(uc, config.DataSourceTypeName, []string{dataSourceTypeName(workspaces.DataSourceListName), workspaceListName})
 }
 
 func (uc UpdatableConfig) WithWorkspaceResource(workspaceName string) AttributeSetter {
-	return func(attributeName string, val cty.Value) UpdatableConfig {
-		file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-		if diags.HasErrors() {
-			panic(diags)
-		}
-
-		workspace := file.Body().FirstMatchingBlock("resource", []string{
-			resourceTypeName(workspaces.ResourceName), workspaceName,
-		})
-		if workspace == nil {
-			panic("config file should contain a block with the workspace resource to add or update an attribute")
-		}
-		_ = workspace.Body().SetAttributeValue(attributeName, val)
-
-		return UpdatableConfig(file.Bytes())
-	}
+	return withAttribute(uc, config.ResourceTypeName, []string{resourceTypeName(workspaces.ResourceName), workspaceName})
 }
 
 func (uc UpdatableConfig) WithWorkspaceGroupResource(workspaceGroupName string) AttributeSetter {
-	return func(attributeName string, val cty.Value) UpdatableConfig {
-		file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-		if diags.HasErrors() {
-			panic(diags)
-		}
-
-		workspace := file.Body().FirstMatchingBlock("resource", []string{
-			resourceTypeName(workspacegroups.ResourceName), workspaceGroupName,
-		})
-		if workspace == nil {
-			panic("config file should contain a block with the workspace group resource to add or update an attribute")
-		}
-		_ = workspace.Body().SetAttributeValue(attributeName, val)
-
-		return UpdatableConfig(file.Bytes())
-	}
+	return withAttribute(uc, config.ResourceTypeName, []string{resourceTypeName(workspacegroups.ResourceName), workspaceGroupName})
 }
 
 // WithAPIKey extends the config with the API key if the key is not empty.
@@ -116,34 +45,16 @@ func (uc UpdatableConfig) WithAPIKey(apiKey string) UpdatableConfig {
 		return uc
 	}
 
-	file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-	if diags.HasErrors() {
-		panic(diags)
-	}
-
-	provider := file.Body().FirstMatchingBlock("provider", []string{config.ProviderName})
-	if provider == nil {
-		panic("config file should contain a block with the provider to add or update an attribute")
-	}
-	_ = provider.Body().SetAttributeValue(config.APIKeyAttribute, cty.StringVal(apiKey))
-
-	return UpdatableConfig(file.Bytes())
+	return withAttribute(uc, config.ProviderTypeName, []string{config.ProviderName})(
+		config.APIKeyAttribute, cty.StringVal(apiKey),
+	)
 }
 
 // WithAPIKeyPath extends the config with the API key path.
 func (uc UpdatableConfig) WithAPIKeyPath(apiKeyPath string) UpdatableConfig {
-	file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-	if diags.HasErrors() {
-		panic(diags)
-	}
-
-	provider := file.Body().FirstMatchingBlock("provider", []string{config.ProviderName})
-	if provider == nil {
-		panic("config file should contain a block with the provider to add or update an attribute")
-	}
-	_ = provider.Body().SetAttributeValue(config.APIKeyPathAttribute, cty.StringVal(apiKeyPath))
-
-	return UpdatableConfig(file.Bytes())
+	return withAttribute(uc, config.ProviderTypeName, []string{config.ProviderName})(
+		config.APIKeyPathAttribute, cty.StringVal(apiKeyPath),
+	)
 }
 
 // WithAPIKey extends the config with the API service url if the url is not empty.
@@ -152,21 +63,45 @@ func (uc UpdatableConfig) WithAPIServiceURL(url string) UpdatableConfig {
 		return uc
 	}
 
-	file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
-	if diags.HasErrors() {
-		panic(diags)
-	}
-
-	provider := file.Body().FirstMatchingBlock("provider", []string{config.ProviderName})
-	if provider == nil {
-		panic("config file should contain a block with the provider to add or update an attribute")
-	}
-	_ = provider.Body().SetAttributeValue(config.APIServiceURLAttribute, cty.StringVal(url))
-
-	return UpdatableConfig(file.Bytes())
+	return withAttribute(uc, config.ProviderTypeName, []string{config.ProviderName})(
+		config.APIServiceURLAttribute, cty.StringVal(url),
+	)
 }
 
-// String shows the result.
+// String shows the resulting *.tf config with all the overrides applied.
 func (uc UpdatableConfig) String() string {
 	return string(uc)
+}
+
+// withAttribute accesses a resource, data source, or a provider defined by the typeName and labels,
+// that is a part of the updatable config and returns a function that enables setting an attribute.
+//
+// This enables reading *.tf files from examples and, in tests, overriding values like
+// an API key of the provider.
+func withAttribute(uc UpdatableConfig, typeName string, labels []string) AttributeSetter {
+	return func(attributeName string, val cty.Value) UpdatableConfig {
+		file, diags := hclwrite.ParseConfig([]byte(uc), "", hcl.InitialPos)
+		if diags.HasErrors() {
+			panic(diags)
+		}
+
+		block := file.Body().FirstMatchingBlock(typeName, labels)
+		if block == nil {
+			message := fmt.Sprintf("config file should contain a block with %s %s to add or update an attribute",
+				typeName, strings.Join(labels, "."),
+			)
+			panic(message)
+		}
+		_ = block.Body().SetAttributeValue(attributeName, val)
+
+		return UpdatableConfig(file.Bytes())
+	}
+}
+
+func resourceTypeName(name string) string {
+	return strings.Join([]string{config.ProviderName, name}, "_")
+}
+
+func dataSourceTypeName(name string) string {
+	return strings.Join([]string{config.ProviderName, name}, "_")
 }

--- a/internal/provider/testutil/updatableconfig_test.go
+++ b/internal/provider/testutil/updatableconfig_test.go
@@ -3,12 +3,47 @@ package testutil_test
 import (
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
 	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestUpdatableConfigWithWorkspace(t *testing.T) {
+func TestWithWorkspaceGroupGetDataSoure(t *testing.T) {
+	uc := testutil.UpdatableConfig(`invalid`)
+	require.Panics(t, func() { _ = uc.WithWorkspaceGroupGetDataSource("this")("foo", cty.StringVal("bar")) })
+	uc = testutil.UpdatableConfig(`data "singlestoredb_workspace_group" "this" {
+	}`)
+	require.Panics(t, func() { _ = uc.WithWorkspaceGroupGetDataSource("no_such_group")("foo", cty.StringVal("bar")) })
+	require.NotContains(t, uc, config.IDAttribute)
+	id := uuid.New().String()
+	uc = uc.WithWorkspaceGroupGetDataSource("this")(config.IDAttribute, cty.StringVal(id))
+	require.Contains(t, uc, config.IDAttribute)
+	require.Contains(t, uc, id)
+}
+
+func TestWithWorkspaceGetDataSoure(t *testing.T) {
+	uc := testutil.UpdatableConfig(`data "singlestoredb_workspace" "this" {
+	}`)
+	require.NotContains(t, uc, config.IDAttribute)
+	id := uuid.New().String()
+	uc = uc.WithWorkspaceGetDataSource("this")(config.IDAttribute, cty.StringVal(id))
+	require.Contains(t, uc, config.IDAttribute)
+	require.Contains(t, uc, id)
+}
+
+func TestWithWorkspaceListDataSoure(t *testing.T) {
+	uc := testutil.UpdatableConfig(`data "singlestoredb_workspaces" "this" {
+	}`)
+	require.NotContains(t, uc, config.IDAttribute)
+	id := uuid.New().String()
+	uc = uc.WithWorkspaceListDataSource("this")(config.IDAttribute, cty.StringVal(id))
+	require.Contains(t, uc, config.IDAttribute)
+	require.Contains(t, uc, id)
+}
+
+func TestWithWorkspaceResource(t *testing.T) {
 	uc := testutil.UpdatableConfig(`resource "singlestoredb_workspace" "example" {
 	}`)
 	require.NotContains(t, uc, "suspended")
@@ -18,4 +53,46 @@ func TestUpdatableConfigWithWorkspace(t *testing.T) {
 	uc = uc.WithWorkspaceResource("example")("suspended", cty.BoolVal(false))
 	require.NotContains(t, uc, "true")
 	require.Contains(t, uc, "false")
+}
+
+func TestWithWorkspaceGroupResource(t *testing.T) {
+	uc := testutil.UpdatableConfig(`resource "singlestoredb_workspace_group" "this" {
+	}`)
+	require.NotContains(t, uc, config.IDAttribute)
+	id := uuid.New().String()
+	uc = uc.WithWorkspaceGroupResource("this")(config.IDAttribute, cty.StringVal(id))
+	require.Contains(t, uc, config.IDAttribute)
+	require.Contains(t, uc, id)
+}
+
+func TestWithAPIKey(t *testing.T) {
+	uc := testutil.UpdatableConfig(`provider "singlestoredb" {
+	}`)
+	require.Equal(t, uc, uc.WithAPIKey(""), "an empty API key changes nothing")
+	apiKey := "abc"
+	require.NotContains(t, uc, config.APIKeyAttribute)
+	uc = uc.WithAPIKey(apiKey)
+	require.Contains(t, uc, config.APIKeyAttribute)
+	require.Contains(t, uc, apiKey)
+}
+
+func TestWithAPIKeyPath(t *testing.T) {
+	uc := testutil.UpdatableConfig(`provider "singlestoredb" {
+	}`)
+	apiKeyPath := "/foo/bar/abc.txt" //nolint:gosec
+	require.NotContains(t, uc, config.APIKeyPathAttribute)
+	uc = uc.WithAPIKeyPath(apiKeyPath)
+	require.Contains(t, uc, config.APIKeyPathAttribute)
+	require.Contains(t, uc, apiKeyPath)
+}
+
+func TestWithAPIServiceURL(t *testing.T) {
+	uc := testutil.UpdatableConfig(`provider "singlestoredb" {
+	}`)
+	require.Equal(t, uc.String(), uc.WithAPIServiceURL("").String(), "an empty URL changes nothing")
+	url := "localhost:8888"
+	require.NotContains(t, uc, config.APIServiceURLAttribute)
+	uc = uc.WithAPIServiceURL(url)
+	require.Contains(t, uc, config.APIServiceURLAttribute)
+	require.Contains(t, uc, url)
 }

--- a/internal/provider/workspacegroups/get_test.go
+++ b/internal/provider/workspacegroups/get_test.go
@@ -52,7 +52,7 @@ func TestReadsWorkspaceGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutil.UpdatableConfig(examples.WorkspaceGroupsGetDataSource).
-					WithWorkspaceGroupGetDataSoure("this")(config.IDAttribute, cty.StringVal(workspaceGroup.WorkspaceGroupID.String())).
+					WithWorkspaceGroupGetDataSource("this")(config.IDAttribute, cty.StringVal(workspaceGroup.WorkspaceGroupID.String())).
 					String(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.singlestoredb_workspace_group.this", config.IDAttribute, workspaceGroup.WorkspaceGroupID.String()),
@@ -90,7 +90,7 @@ func TestWorkspaceGroupNotFound(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutil.UpdatableConfig(examples.WorkspaceGroupsGetDataSource).
-					WithWorkspaceGroupGetDataSoure("this")(config.IDAttribute, cty.StringVal(uuid.New().String())).
+					WithWorkspaceGroupGetDataSource("this")(config.IDAttribute, cty.StringVal(uuid.New().String())).
 					String(),
 				ExpectError: regexp.MustCompile(http.StatusText(http.StatusNotFound)),
 			},
@@ -112,7 +112,7 @@ func TestInvalidInputUUID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutil.UpdatableConfig(examples.WorkspaceGroupsGetDataSource).
-					WithWorkspaceGroupGetDataSoure("this")(config.IDAttribute, cty.StringVal("valid-uuid")).
+					WithWorkspaceGroupGetDataSource("this")(config.IDAttribute, cty.StringVal("valid-uuid")).
 					String(),
 				ExpectError: regexp.MustCompile("invalid UUID"),
 			},
@@ -127,7 +127,7 @@ func TestGetWorkspaceGroupNotFoundIntegration(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutil.UpdatableConfig(examples.WorkspaceGroupsGetDataSource).
-					WithWorkspaceGroupGetDataSoure("this")(config.IDAttribute, cty.StringVal(uuid.New().String())).
+					WithWorkspaceGroupGetDataSource("this")(config.IDAttribute, cty.StringVal(uuid.New().String())).
 					String(),
 				ExpectError: regexp.MustCompile(http.StatusText(http.StatusNotFound)), // Checking that at least the expected error.
 			},

--- a/internal/provider/workspaces/list_test.go
+++ b/internal/provider/workspaces/list_test.go
@@ -81,7 +81,7 @@ func TestReadsWorkspaces(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutil.UpdatableConfig(examples.WorkspacesListDataSource).
-					WithWorkspaceListDataSoure("all")(config.WorkspaceGroupIDAttribute, cty.StringVal(workspaceGroups[0].WorkspaceGroupID.String())).
+					WithWorkspaceListDataSource("all")(config.WorkspaceGroupIDAttribute, cty.StringVal(workspaceGroups[0].WorkspaceGroupID.String())).
 					String(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.singlestoredb_workspaces.all", config.IDAttribute, config.TestIDValue),
@@ -136,7 +136,7 @@ func TestListWorkspacesWorkspaceGroupNotFoundIntegration(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutil.UpdatableConfig(examples.WorkspacesListDataSource).
-					WithWorkspaceListDataSoure("all")(config.WorkspaceGroupIDAttribute, cty.StringVal(uuid.New().String())).
+					WithWorkspaceListDataSource("all")(config.WorkspaceGroupIDAttribute, cty.StringVal(uuid.New().String())).
 					String(),
 				ExpectError: regexp.MustCompile(http.StatusText(http.StatusNotFound)), // Checking that at least the expected error.
 			},


### PR DESCRIPTION
Before proceeding with more detailed tests for `resources` and `datasources`, improving the `testutils` coverage. Ignoring coverage of the `testutil.go` file because it is tested indirectly and does not require extra tests.