### PR TITLE
Updating releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        version: "~> v2"
         with:
           args: release --clean
         env:


### PR DESCRIPTION
I need to upgrade the releaser because "git tag vXXX && git push vXXX" - to release the new version of the provider - failed

https://github.com/singlestore-labs/terraform-provider-singlestoredb/actions/runs/10810991567/job/29989414795

https://goreleaser.com/blog/goreleaser-v2/#upgrading