### PR TITLE
Updating the releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
@@ -35,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --snapshot --debug
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,8 @@ name: Release
 # "v*" (e.g. v0.1.0) is created.
 on:
   push:
-    branches:
-      - debugging-releaser
     tags:
       - 'v*'
-  workflow_dispatch:
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
@@ -38,7 +35,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean --snapshot
+          args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean --snapshot --debug
+          args: release --clean --snapshot
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ name: Release
 # "v*" (e.g. v0.1.0) is created.
 on:
   push:
+    branches:
+      - debugging-releaser
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -56,5 +57,3 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
-changelog:
-  skip: true


### PR DESCRIPTION
The releaser stopped working some time ago and the previous attempts
- 1ec99358f54a162f487a1c3cd06f68eeb9c82231
- a603665f901179b6f617ceefe43c7bcd61238f25
were not enough.

I had to introduce some more changes. The missing part was updating the releaser config (in addition to the the workflow config).

I tested with my branch name, on push, to release with the flag `--snapshot` which is effectively a dry run and it worked
https://github.com/singlestore-labs/terraform-provider-singlestoredb/actions/runs/12318804593/job/34384359049.