### PR TITLE
Fixing kai_enabled=false

### DIFF
--- a/internal/provider/workspaces/resource.go
+++ b/internal/provider/workspaces/resource.go
@@ -104,7 +104,9 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 					boolplanmodifier.UseStateForUnknown(),
 				},
 				Optional:            true,
+				Computed:            true,
 				MarkdownDescription: "Whether the Kai API is enabled for the workspace.",
+				Default:             booldefault.StaticBool(false),
 			},
 		},
 	}
@@ -334,7 +336,7 @@ func toWorkspaceResourceModel(workspace management.Workspace) workspaceResourceM
 		Suspended:        types.BoolValue(workspace.State == management.WorkspaceStateSUSPENDED),
 		CreatedAt:        types.StringValue(workspace.CreatedAt),
 		Endpoint:         util.MaybeStringValue(workspace.Endpoint),
-		KaiEnabled:       util.MaybeBoolValue(workspace.KaiEnabled),
+		KaiEnabled:       types.BoolValue(util.Deref(workspace.KaiEnabled)),
 	}
 }
 


### PR DESCRIPTION
When creating a new workspace with kai_enabled = false we receive the following error:
If we create it with kai_enabled = true or kai_enabled = null it works.
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to module.singlestoredb_workspace["ui"].singlestoredb_workspace.this, provider "provider[\"

Tested manually all the cases:
1. not indicating the field (null)
2. false
3. true

And all created workspaces without issues, unlike before.

https://memsql.atlassian.net/browse/ECS-1750
https://memsql.slack.com/archives/C04Q32QQBT6/p1734595727129479