### PR TITLE
Fixing azure case mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ terraform-provider-singlestoredb
 *.tfstate.backup
 .terraformrc
 *.out
+.env

--- a/docs/resources/workspace_group.md
+++ b/docs/resources/workspace_group.md
@@ -40,7 +40,7 @@ resource "singlestoredb_workspace_group" "this" {
 ### Optional
 
 - `admin_password` (String, Sensitive) The admin SQL user password for the workspace group. If not provided, the server will automatically generate a secure password. Please note that updates to the admin password might take a brief moment to become effective.
-- `cloud_provider` (String) The name of the cloud provider used to resolve region. Possible values are 'AWS', 'GCP', and 'AZURE'.
+- `cloud_provider` (String) The name of the cloud provider used to resolve region. Possible values are 'AWS', 'GCP', and 'Azure'.
 - `deployment_type` (String) The deployment type that will be applied to all the workspaces within the workspace group. It can have one of the following values: `PRODUCTION` or `NON-PRODUCTION`. The default value is `PRODUCTION`.
 - `expires_at` (String) The expiration timestamp of the workspace group. If not specified, the workspace group never expires. Upon expiration, the workspace group is terminated and all its data is lost. Set the expiration time as an RFC3339 UTC timestamp, e.g., "2221-01-02T15:04:05Z".
 - `high_availability_two_zones` (Boolean) Enables deployment across two Availability Zones.

--- a/examples/resources/singlestoredb_workspace_group_azure/resource.tf
+++ b/examples/resources/singlestoredb_workspace_group_azure/resource.tf
@@ -1,0 +1,14 @@
+provider "singlestoredb" {
+  // The SingleStoreDB Terraform provider uses the SINGLESTOREDB_API_KEY environment variable for authentication.
+  // Please set this environment variable with your SingleStore Management API key.
+  // You can generate this key from the SingleStore Portal at https://portal.singlestore.com/organizations/org-id/api-keys.
+}
+
+resource "singlestoredb_workspace_group" "this" {
+  name            = "group"
+  firewall_ranges = ["0.0.0.0/0"] // Ensure restrictive ranges for production environments.
+  expires_at      = "2222-01-01T00:00:00Z"
+  cloud_provider  = "Azure"
+  region_name     = "eastus2"
+  admin_password  = "mockPassword193!"
+}

--- a/internal/provider/util/converters.go
+++ b/internal/provider/util/converters.go
@@ -202,13 +202,13 @@ func WorkspaceGroupUpdateDeploymentTypeString(wgs types.String) *management.Work
 	return nil
 }
 
-func WorkspaceGroupCloudProviderString(provider types.String) *management.WorkspaceGroupCreateProvider {
+func WorkspaceGroupCloudProviderString(provider string) *management.WorkspaceGroupCreateProvider {
 	for _, s := range []management.WorkspaceGroupCreateProvider{
 		management.WorkspaceGroupCreateProviderAWS,
 		management.WorkspaceGroupCreateProviderAzure,
 		management.WorkspaceGroupCreateProviderGCP,
 	} {
-		if strings.EqualFold(provider.ValueString(), string(s)) {
+		if strings.EqualFold(provider, string(s)) {
 			return &s
 		}
 	}


### PR DESCRIPTION
https://memsql.atlassian.net/browse/ECS-2762?actionerId=62dab3c777308a9694e291c4&sourceType=assign

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to singlestoredb_workspace_group.example, provider "provider[\"registry.terraform.io/singlestore-labs/singlestoredb\"]" produced an unexpected new value: .cloud_provider: was cty.StringVal("Azure"), but now
│ cty.StringVal("AZURE").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

The issue is that `POST /workspaceGroups` expects `Azure` yet `GET /workspaceGroups` returns `AZURE`.

Fixing it both here and at the Management API layer https://github.com/singlestore/helios/pull/19338