### PR TITLE
feat: Add project resource

### DIFF
--- a/examples/embed.go
+++ b/examples/embed.go
@@ -45,6 +45,7 @@ var (
 	FlowGetDataSource                = mustRead("data-sources/singlestoredb_flow/data-source.tf")
 	FlowListDataSource               = mustRead("data-sources/singlestoredb_flows/data-source.tf")
 	FlowResource                     = mustRead("resources/singlestoredb_flow/resource.tf")
+	ProjectResource                  = mustRead("resources/singlestoredb_project/resource.tf")
 )
 
 func mustRead(path string) string {

--- a/examples/resources/singlestoredb_project/resource.tf
+++ b/examples/resources/singlestoredb_project/resource.tf
@@ -1,0 +1,14 @@
+provider "singlestoredb" {
+  // The SingleStoreDB Terraform provider uses the SINGLESTOREDB_API_KEY environment variable for authentication.
+  // Please set this environment variable with your SingleStore Management API key.
+  // You can generate this key from the SingleStore Portal at https://portal.singlestore.com/organizations/org-id/api-keys.
+}
+
+resource "singlestoredb_project" "this" {
+  name    = "my-project"
+  edition = "STANDARD"
+}
+
+output "singlestoredb_project_id" {
+  value = singlestoredb_project.this.id
+}

--- a/examples/resources/singlestoredb_project/resource.tf
+++ b/examples/resources/singlestoredb_project/resource.tf
@@ -5,7 +5,7 @@ provider "singlestoredb" {
 }
 
 resource "singlestoredb_project" "this" {
-  name    = "my-project"
+  name    = "project"
   edition = "STANDARD"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
-	github.com/singlestore-labs/singlestore-go/management v1.2.147
+	github.com/singlestore-labs/singlestore-go/management v1.2.149
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/singlestore-labs/singlestore-go/management v1.2.147 h1:g1cqlcUvthcOg19geo1paeHzgnRR+eidAGwy12n6nr0=
-github.com/singlestore-labs/singlestore-go/management v1.2.147/go.mod h1:pfeKQbKr6ml61j823Pi4RUnBTug1buSxLJDmGINAoKc=
+github.com/singlestore-labs/singlestore-go/management v1.2.149 h1:AOqq+R81LwshC3CSsloPp4W7ck5jztsMsl9cR+dAewc=
+github.com/singlestore-labs/singlestore-go/management v1.2.149/go.mod h1:pfeKQbKr6ml61j823Pi4RUnBTug1buSxLJDmGINAoKc=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=

--- a/internal/provider/projects/resource.go
+++ b/internal/provider/projects/resource.go
@@ -88,12 +88,14 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	})
 	if serr := util.StatusOK(createResp, err); serr != nil {
 		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+
 		return
 	}
 
 	project, err := r.GetV1ProjectsProjectIDWithResponse(ctx, createResp.JSON200.ProjectID)
 	if serr := util.StatusOK(project, err); serr != nil {
 		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+
 		return
 	}
 
@@ -113,10 +115,13 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	project, err := r.GetV1ProjectsProjectIDWithResponse(ctx, uuid.MustParse(state.ID.ValueString()))
 	if serr := util.StatusOK(project, err, util.ReturnNilOnNotFound); serr != nil {
 		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+
 		return
 	}
+
 	if project.StatusCode() == http.StatusNotFound {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -139,12 +144,14 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	})
 	if serr := util.StatusOK(patchResp, err); serr != nil {
 		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+
 		return
 	}
 
 	project, err := r.GetV1ProjectsProjectIDWithResponse(ctx, id)
 	if serr := util.StatusOK(project, err); serr != nil {
 		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+
 		return
 	}
 
@@ -164,6 +171,7 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 	deleteResp, err := r.DeleteV1ProjectsProjectIDWithResponse(ctx, uuid.MustParse(state.ID.ValueString()))
 	if serr := util.StatusOK(deleteResp, err, util.ReturnNilOnNotFound); serr != nil {
 		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+
 		return
 	}
 }

--- a/internal/provider/projects/resource.go
+++ b/internal/provider/projects/resource.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/singlestore-labs/singlestore-go/management"
 	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
@@ -62,6 +64,9 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"edition": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The edition of the project. Valid values are: ENTERPRISE, STANDARD, SHARED.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(string(management.ENTERPRISE), string(management.STANDARD), string(management.SHARED)),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/projects/resource.go
+++ b/internal/provider/projects/resource.go
@@ -1,0 +1,213 @@
+package projects
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/singlestore-labs/singlestore-go/management"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/util"
+)
+
+const (
+	ResourceName = "project"
+)
+
+var (
+	_ resource.ResourceWithConfigure   = &projectResource{}
+	_ resource.ResourceWithModifyPlan  = &projectResource{}
+	_ resource.ResourceWithImportState = &projectResource{}
+)
+
+type projectResourceModel struct {
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	Edition   types.String `tfsdk:"edition"`
+	CreatedAt types.String `tfsdk:"created_at"`
+}
+
+type projectResource struct {
+	management.ClientWithResponsesInterface
+}
+
+func NewResource() resource.Resource {
+	return &projectResource{}
+}
+
+func (r *projectResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = util.ResourceTypeName(req, ResourceName)
+}
+
+func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manage SingleStoreDB projects with this resource. Projects are used to organize workspace groups. The 'apply' action creates a new project or updates an existing one. The 'destroy' action deletes the project.",
+		Attributes: map[string]schema.Attribute{
+			config.IDAttribute: schema.StringAttribute{
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the project.",
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The name of the project.",
+			},
+			"edition": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The edition of the project. Valid values are: ENTERPRISE, STANDARD, SHARED.",
+			},
+			"created_at": schema.StringAttribute{
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Computed:            true,
+				MarkdownDescription: "The timestamp when the project was created.",
+			},
+		},
+	}
+}
+
+func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan projectResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createResp, err := r.PostV1ProjectsWithResponse(ctx, management.PostV1ProjectsJSONRequestBody{
+		Name:    util.ToString(plan.Name),
+		Edition: management.ProjectEdition(plan.Edition.ValueString()),
+	})
+	if serr := util.StatusOK(createResp, err); serr != nil {
+		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+		return
+	}
+
+	project, err := r.GetV1ProjectsProjectIDWithResponse(ctx, createResp.JSON200.ProjectID)
+	if serr := util.StatusOK(project, err); serr != nil {
+		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+		return
+	}
+
+	result := toProjectResourceModel(*project.JSON200)
+	diags = resp.State.Set(ctx, &result)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state projectResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	project, err := r.GetV1ProjectsProjectIDWithResponse(ctx, uuid.MustParse(state.ID.ValueString()))
+	if serr := util.StatusOK(project, err, util.ReturnNilOnNotFound); serr != nil {
+		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+		return
+	}
+	if project.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state = toProjectResourceModel(*project.JSON200)
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan projectResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := uuid.MustParse(plan.ID.ValueString())
+	patchResp, err := r.PatchV1ProjectsProjectIDWithResponse(ctx, id, management.PatchV1ProjectsProjectIDJSONRequestBody{
+		Name: util.ToString(plan.Name),
+	})
+	if serr := util.StatusOK(patchResp, err); serr != nil {
+		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+		return
+	}
+
+	project, err := r.GetV1ProjectsProjectIDWithResponse(ctx, id)
+	if serr := util.StatusOK(project, err); serr != nil {
+		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+		return
+	}
+
+	result := toProjectResourceModel(*project.JSON200)
+	diags = resp.State.Set(ctx, &result)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state projectResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteResp, err := r.DeleteV1ProjectsProjectIDWithResponse(ctx, uuid.MustParse(state.ID.ValueString()))
+	if serr := util.StatusOK(deleteResp, err, util.ReturnNilOnNotFound); serr != nil {
+		resp.Diagnostics.AddError(serr.Summary, serr.Detail)
+		return
+	}
+}
+
+func (r *projectResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	var state *projectResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || state == nil {
+		return
+	}
+
+	var plan *projectResourceModel
+	diags = req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || plan == nil {
+		return
+	}
+
+	if !plan.Edition.Equal(state.Edition) {
+		resp.Diagnostics.AddError(
+			"Cannot update edition",
+			"Updating the \"edition\" field is not allowed. Current value: \""+state.Edition.ValueString()+"\", configured value: \""+plan.Edition.ValueString()+"\". Please explicitly delete the project before changing its edition.",
+		)
+	}
+}
+
+func (r *projectResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return // Should not return an error for unknown reasons.
+	}
+
+	r.ClientWithResponsesInterface = req.ProviderData.(management.ClientWithResponsesInterface)
+}
+
+func (r *projectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	util.ImportStatePassthroughID(ctx, req, resp)
+}
+
+func toProjectResourceModel(project management.Project) projectResourceModel {
+	return projectResourceModel{
+		ID:        util.UUIDStringValue(project.ProjectID),
+		Name:      types.StringValue(project.Name),
+		Edition:   types.StringValue(string(project.Edition)),
+		CreatedAt: types.StringValue(project.CreatedAt.String()),
+	}
+}

--- a/internal/provider/projects/resource_test.go
+++ b/internal/provider/projects/resource_test.go
@@ -39,7 +39,7 @@ func TestCRUDProject(t *testing.T) {
 		var input management.ProjectCreate
 		require.NoError(t, json.Unmarshal(body, &input))
 		require.Equal(t, project.Name, input.Name)
-		require.Equal(t, management.ProjectEdition(project.Edition), input.Edition)
+		require.Equal(t, project.Edition, input.Edition)
 
 		w.Header().Add("Content-Type", "application/json")
 		_, err = w.Write(testutil.MustJSON(management.ProjectIDResponse{

--- a/internal/provider/projects/resource_test.go
+++ b/internal/provider/projects/resource_test.go
@@ -22,7 +22,7 @@ import (
 
 var testProject = management.Project{
 	ProjectID: uuid.MustParse("ad2eb3f8-ef7c-4eb5-b530-6f0930db9ff8"),
-	Name:      "my-project",
+	Name:      "project",
 	Edition:   management.STANDARD,
 	CreatedAt: time.Date(2024, time.January, 15, 9, 10, 11, 0, time.UTC),
 }
@@ -211,7 +211,7 @@ func TestCRUDProjectIntegration(t *testing.T) {
 				Config: examples.ProjectResource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("singlestoredb_project.this", config.IDAttribute),
-					resource.TestCheckResourceAttr("singlestoredb_project.this", "name", "my-project"),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "name", "project"),
 					resource.TestCheckResourceAttr("singlestoredb_project.this", "edition", "STANDARD"),
 					resource.TestCheckResourceAttrSet("singlestoredb_project.this", "created_at"),
 				),

--- a/internal/provider/projects/resource_test.go
+++ b/internal/provider/projects/resource_test.go
@@ -202,6 +202,59 @@ func TestImportProject(t *testing.T) {
 	})
 }
 
+func TestUpdateEditionNotAllowed(t *testing.T) {
+	project := testProject
+
+	projectGetPath := strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write(testutil.MustJSON(management.ProjectIDResponse{
+				ProjectID: project.ProjectID,
+			}))
+			require.NoError(t, err)
+		case r.URL.Path == projectGetPath && r.Method == http.MethodGet:
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write(testutil.MustJSON(project))
+			require.NoError(t, err)
+		case r.Method == http.MethodDelete:
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write(testutil.MustJSON(management.ProjectIDResponse{
+				ProjectID: project.ProjectID,
+			}))
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	testutil.UnitTest(t, testutil.UnitTestConfig{
+		APIServiceURL: server.URL,
+		APIKey:        testutil.UnusedAPIKey,
+	}, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: examples.ProjectResource,
+			},
+			{
+				Config: `
+provider "singlestoredb" {
+}
+
+resource "singlestoredb_project" "this" {
+  name    = "project"
+  edition = "ENTERPRISE"
+}
+`,
+				ExpectError: regexp.MustCompile("Cannot update edition"),
+			},
+		},
+	})
+}
+
 func TestCRUDProjectIntegration(t *testing.T) {
 	testutil.IntegrationTest(t, testutil.IntegrationTestConfig{
 		APIKey: os.Getenv(config.EnvTestAPIKey),

--- a/internal/provider/projects/resource_test.go
+++ b/internal/provider/projects/resource_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const projectsPath = "/v1/projects"
+
 var testProject = management.Project{
 	ProjectID: uuid.MustParse("ad2eb3f8-ef7c-4eb5-b530-6f0930db9ff8"),
 	Name:      "project",
@@ -31,7 +33,7 @@ func TestCRUDProject(t *testing.T) {
 	project := testProject
 
 	projectPostHandler := func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/projects", r.URL.Path)
+		require.Equal(t, projectsPath, r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
 		body, err := io.ReadAll(r.Body)
@@ -48,7 +50,7 @@ func TestCRUDProject(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	projectGetPath := strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/")
+	projectGetPath := strings.Join([]string{projectsPath, project.ProjectID.String()}, "/")
 
 	projectGetHandler := func(w http.ResponseWriter, r *http.Request) bool {
 		if r.URL.Path != projectGetPath || r.Method != http.MethodGet {
@@ -63,7 +65,7 @@ func TestCRUDProject(t *testing.T) {
 	}
 
 	projectPatchHandler := func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/"), r.URL.Path)
+		require.Equal(t, strings.Join([]string{projectsPath, project.ProjectID.String()}, "/"), r.URL.Path)
 		require.Equal(t, http.MethodPatch, r.Method)
 
 		body, err := io.ReadAll(r.Body)
@@ -81,7 +83,7 @@ func TestCRUDProject(t *testing.T) {
 	}
 
 	projectDeleteHandler := func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/"), r.URL.Path)
+		require.Equal(t, strings.Join([]string{projectsPath, project.ProjectID.String()}, "/"), r.URL.Path)
 		require.Equal(t, http.MethodDelete, r.Method)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -93,7 +95,7 @@ func TestCRUDProject(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+		case r.URL.Path == projectsPath && r.Method == http.MethodPost:
 			projectPostHandler(w, r)
 		case projectGetHandler(w, r):
 			// handled
@@ -163,11 +165,11 @@ func TestCreateProjectError(t *testing.T) {
 func TestImportProject(t *testing.T) {
 	project := testProject
 
-	projectGetPath := strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/")
+	projectGetPath := strings.Join([]string{projectsPath, project.ProjectID.String()}, "/")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+		case r.URL.Path == projectsPath && r.Method == http.MethodPost:
 			w.Header().Add("Content-Type", "application/json")
 			_, err := w.Write(testutil.MustJSON(management.ProjectIDResponse{
 				ProjectID: project.ProjectID,
@@ -205,11 +207,11 @@ func TestImportProject(t *testing.T) {
 func TestUpdateEditionNotAllowed(t *testing.T) {
 	project := testProject
 
-	projectGetPath := strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/")
+	projectGetPath := strings.Join([]string{projectsPath, project.ProjectID.String()}, "/")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+		case r.URL.Path == projectsPath && r.Method == http.MethodPost:
 			w.Header().Add("Content-Type", "application/json")
 			_, err := w.Write(testutil.MustJSON(management.ProjectIDResponse{
 				ProjectID: project.ProjectID,

--- a/internal/provider/projects/resource_test.go
+++ b/internal/provider/projects/resource_test.go
@@ -1,0 +1,221 @@
+package projects_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/singlestore-labs/singlestore-go/management"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/examples"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var testProject = management.Project{
+	ProjectID: uuid.MustParse("ad2eb3f8-ef7c-4eb5-b530-6f0930db9ff8"),
+	Name:      "my-project",
+	Edition:   management.STANDARD,
+	CreatedAt: time.Date(2024, time.January, 15, 9, 10, 11, 0, time.UTC),
+}
+
+func TestCRUDProject(t *testing.T) {
+	project := testProject
+
+	projectPostHandler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/projects", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var input management.ProjectCreate
+		require.NoError(t, json.Unmarshal(body, &input))
+		require.Equal(t, project.Name, input.Name)
+		require.Equal(t, management.ProjectEdition(project.Edition), input.Edition)
+
+		w.Header().Add("Content-Type", "application/json")
+		_, err = w.Write(testutil.MustJSON(management.ProjectIDResponse{
+			ProjectID: project.ProjectID,
+		}))
+		require.NoError(t, err)
+	}
+
+	projectGetPath := strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/")
+
+	projectGetHandler := func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path != projectGetPath || r.Method != http.MethodGet {
+			return false
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		_, err := w.Write(testutil.MustJSON(project))
+		require.NoError(t, err)
+
+		return true
+	}
+
+	projectPatchHandler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/"), r.URL.Path)
+		require.Equal(t, http.MethodPatch, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var input management.ProjectUpdate
+		require.NoError(t, json.Unmarshal(body, &input))
+
+		project.Name = input.Name
+
+		w.Header().Add("Content-Type", "application/json")
+		_, err = w.Write(testutil.MustJSON(management.ProjectIDResponse{
+			ProjectID: project.ProjectID,
+		}))
+		require.NoError(t, err)
+	}
+
+	projectDeleteHandler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/"), r.URL.Path)
+		require.Equal(t, http.MethodDelete, r.Method)
+
+		w.Header().Add("Content-Type", "application/json")
+		_, err := w.Write(testutil.MustJSON(management.ProjectIDResponse{
+			ProjectID: project.ProjectID,
+		}))
+		require.NoError(t, err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+			projectPostHandler(w, r)
+		case projectGetHandler(w, r):
+			// handled
+		case r.Method == http.MethodPatch:
+			projectPatchHandler(w, r)
+		case r.Method == http.MethodDelete:
+			projectDeleteHandler(w, r)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	testutil.UnitTest(t, testutil.UnitTestConfig{
+		APIServiceURL: server.URL,
+		APIKey:        testutil.UnusedAPIKey,
+	}, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: examples.ProjectResource,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("singlestoredb_project.this", config.IDAttribute, testProject.ProjectID.String()),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "name", testProject.Name),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "edition", string(testProject.Edition)),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "created_at", testProject.CreatedAt.String()),
+				),
+			},
+			{
+				Config: `
+provider "singlestoredb" {
+}
+
+resource "singlestoredb_project" "this" {
+  name    = "updated-project"
+  edition = "STANDARD"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("singlestoredb_project.this", config.IDAttribute, testProject.ProjectID.String()),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "name", "updated-project"),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "edition", string(testProject.Edition)),
+				),
+			},
+		},
+	})
+}
+
+func TestCreateProjectError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	testutil.UnitTest(t, testutil.UnitTestConfig{
+		APIServiceURL: server.URL,
+		APIKey:        "bar",
+	}, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      examples.ProjectResource,
+				ExpectError: regexp.MustCompile(http.StatusText(http.StatusUnauthorized)),
+			},
+		},
+	})
+}
+
+func TestImportProject(t *testing.T) {
+	project := testProject
+
+	projectGetPath := strings.Join([]string{"/v1/projects", project.ProjectID.String()}, "/")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write(testutil.MustJSON(management.ProjectIDResponse{
+				ProjectID: project.ProjectID,
+			}))
+			require.NoError(t, err)
+		case r.URL.Path == projectGetPath && r.Method == http.MethodGet:
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write(testutil.MustJSON(project))
+			require.NoError(t, err)
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	testutil.UnitTest(t, testutil.UnitTestConfig{
+		APIServiceURL: server.URL,
+		APIKey:        testutil.UnusedAPIKey,
+	}, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: examples.ProjectResource,
+			},
+			{
+				ResourceName:      "singlestoredb_project.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestCRUDProjectIntegration(t *testing.T) {
+	testutil.IntegrationTest(t, testutil.IntegrationTestConfig{
+		APIKey: os.Getenv(config.EnvTestAPIKey),
+	}, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: examples.ProjectResource,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("singlestoredb_project.this", config.IDAttribute),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "name", "my-project"),
+					resource.TestCheckResourceAttr("singlestoredb_project.this", "edition", "STANDARD"),
+					resource.TestCheckResourceAttrSet("singlestoredb_project.this", "created_at"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -198,6 +198,7 @@ func (p *singlestoreProvider) Resources(_ context.Context) []func() resource.Res
 		roles.NewTeamRolesGrantResource,
 		roles.NewRoleResource,
 		flow.NewResource,
+		projects.NewResource,
 	}
 }
 


### PR DESCRIPTION
Jira Issue: [MCDB-90473](https://memsql.atlassian.net/browse/MCDB-90473)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CRUD Terraform resource backed by live Management API calls, which may affect user-managed infrastructure state if behavior or validation is incorrect. Changes are isolated to the new resource plus provider registration and dependency bump.
> 
> **Overview**
> Adds a new `singlestoredb_project` Terraform resource to create, read, update (name only), delete, and import SingleStoreDB projects via the Management API, including schema validation for `edition` and a plan-time guard that rejects edition changes.
> 
> Wires the new resource into the provider, adds an example config for it, and bumps `singlestore-go/management` to `v1.2.149` with accompanying `go.sum` updates; includes unit + integration tests covering CRUD, import, API error handling, and the edition-change restriction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18532715e24f9f55fde0554234647da6a372da99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MCDB-90473]: https://memsql.atlassian.net/browse/MCDB-90473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ