### PR TITLE
fix(teams): make member_teams and member_users sets instead of lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- `singlestoredb_team`: `member_users` and `member_teams` are now sets of strings instead of lists. This removes order-sensitive plan diffs when the backend returns members in a different order than configured. Existing state from prior provider versions is read transparently; no manual migration is required.

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -3,12 +3,12 @@
 page_title: "singlestoredb_team Resource - terraform-provider-singlestoredb"
 subcategory: ""
 description: |-
-  Manage SingleStoreDB teams with this resource. The 'apply' action creates a new team or updates an existing one. You can add/remove users to/from the team by specifying their email addresses in the 'member_users' list. You can also add/remove other teams to/from this team by specifying their IDs in the 'member_teams' list. The 'destroy' action deletes the team. Updating the 'member_users' or 'member_teams' lists will add or remove the corresponding users or teams from the team.
+  Manage SingleStoreDB teams with this resource. The 'apply' action creates a new team or updates an existing one. You can add/remove users to/from the team by specifying their email addresses in the 'member_users' set. You can also add/remove other teams to/from this team by specifying their IDs in the 'member_teams' set. The 'destroy' action deletes the team. Updating the 'member_users' or 'member_teams' sets will add or remove the corresponding users or teams from the team.
 ---
 
 # singlestoredb_team (Resource)
 
-Manage SingleStoreDB teams with this resource. The 'apply' action creates a new team or updates an existing one. You can add/remove users to/from the team by specifying their email addresses in the 'member_users' list. You can also add/remove other teams to/from this team by specifying their IDs in the 'member_teams' list. The 'destroy' action deletes the team. Updating the 'member_users' or 'member_teams' lists will add or remove the corresponding users or teams from the team.
+Manage SingleStoreDB teams with this resource. The 'apply' action creates a new team or updates an existing one. You can add/remove users to/from the team by specifying their email addresses in the 'member_users' set. You can also add/remove other teams to/from this team by specifying their IDs in the 'member_teams' set. The 'destroy' action deletes the team. Updating the 'member_users' or 'member_teams' sets will add or remove the corresponding users or teams from the team.
 
 ## Example Usage
 
@@ -41,8 +41,8 @@ output "singlestoredb_team_id" {
 ### Optional
 
 - `description` (String) The description of the team.
-- `member_teams` (List of String) List of team UUIDs that are members of this team.
-- `member_users` (List of String) List of user emails that are members of this team.
+- `member_teams` (Set of String) Set of team UUIDs that are members of this team.
+- `member_users` (Set of String) Set of user emails that are members of this team.
 
 ### Read-Only
 

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -166,13 +166,13 @@ func (r *teamResource) addInitialMembers(ctx context.Context, diags *diag.Diagno
 		return false
 	}
 
-	if (memberEmails == nil || len(*memberEmails) == 0) && (teamIDs == nil || len(*teamIDs) == 0) {
+	if len(memberEmails) == 0 && len(teamIDs) == 0 {
 		return true
 	}
 
 	teamPatchResponse, err := r.PatchV1TeamsTeamIDWithResponse(ctx, id, management.PatchV1TeamsTeamIDJSONRequestBody{
-		AddMemberUserEmails: memberEmails,
-		AddMemberTeamIDs:    teamIDs,
+		AddMemberUserEmails: &memberEmails,
+		AddMemberTeamIDs:    &teamIDs,
 	})
 	if serr := util.StatusOK(teamPatchResponse, err); serr != nil {
 		diags.AddError(serr.Summary, serr.Detail)
@@ -245,10 +245,10 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		teamPatchResponse, err := r.PatchV1TeamsTeamIDWithResponse(ctx, id, management.PatchV1TeamsTeamIDJSONRequestBody{
 			Name:                   util.MaybeString(plan.Name),
 			Description:            util.MaybeString(plan.Description),
-			AddMemberUserEmails:    addedUsers,
-			RemoveMemberUserEmails: removedUsers,
-			AddMemberTeamIDs:       addedTeams,
-			RemoveMemberTeamIDs:    removedTeams,
+			AddMemberUserEmails:    &addedUsers,
+			RemoveMemberUserEmails: &removedUsers,
+			AddMemberTeamIDs:       &addedTeams,
+			RemoveMemberTeamIDs:    &removedTeams,
 		})
 		if serr := util.StatusOK(teamPatchResponse, err); serr != nil {
 			resp.Diagnostics.AddError(
@@ -272,7 +272,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) (*[]string, *[]string, *[]otypes.UUID, *[]otypes.UUID) {
+func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) ([]string, []string, []otypes.UUID, []otypes.UUID) {
 	addedUsers, err := util.ValidateAndMapUserEmails(ctx, plan.MemberUsers, state.MemberUsers, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
@@ -296,8 +296,8 @@ func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.U
 	return addedUsers, removedUsers, addedTeams, removedTeams
 }
 
-func (r *teamResource) shouldUpdate(state, plan TeamResourceModel, addedUsers, removedUsers *[]string, addedTeams, removedTeams *[]otypes.UUID) bool {
-	return addedUsers != nil || removedUsers != nil || addedTeams != nil || removedTeams != nil || plan.Name != state.Name || plan.Description != state.Description
+func (r *teamResource) shouldUpdate(state, plan TeamResourceModel, addedUsers, removedUsers []string, addedTeams, removedTeams []otypes.UUID) bool {
+	return len(addedUsers) > 0 || len(removedUsers) > 0 || len(addedTeams) > 0 || len(removedTeams) > 0 || plan.Name != state.Name || plan.Description != state.Description
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -148,14 +148,14 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 func (r *teamResource) addInitialMembers(ctx context.Context, diags *diag.Diagnostics, id otypes.UUID, plan TeamResourceModel) bool {
 	emptyStrings := types.SetNull(types.StringType)
 
-	memberEmails, err := util.ValidateAndMapUserEmails(ctx, plan.MemberUsers, emptyStrings, diags)
+	memberEmails, err := util.ValidateUserEmailDiff(ctx, plan.MemberUsers, emptyStrings, diags)
 	if err != nil {
 		diags.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 
 		return false
 	}
 
-	teamIDs, err := util.ParseUUIDSets(ctx, plan.MemberTeams, emptyStrings, diags)
+	teamIDs, err := util.ValidateUUIDDiff(ctx, plan.MemberTeams, emptyStrings, diags)
 	if err != nil {
 		diags.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 
@@ -273,22 +273,22 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) ([]string, []string, []otypes.UUID, []otypes.UUID) {
-	addedUsers, err := util.ValidateAndMapUserEmails(ctx, plan.MemberUsers, state.MemberUsers, &resp.Diagnostics)
+	addedUsers, err := util.ValidateUserEmailDiff(ctx, plan.MemberUsers, state.MemberUsers, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 	}
 
-	removedUsers, err := util.ValidateAndMapUserEmails(ctx, state.MemberUsers, plan.MemberUsers, &resp.Diagnostics)
+	removedUsers, err := util.ValidateUserEmailDiff(ctx, state.MemberUsers, plan.MemberUsers, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 	}
 
-	addedTeams, err := util.ParseUUIDSets(ctx, plan.MemberTeams, state.MemberTeams, &resp.Diagnostics)
+	addedTeams, err := util.ValidateUUIDDiff(ctx, plan.MemberTeams, state.MemberTeams, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 	}
 
-	removedTeams, err := util.ParseUUIDSets(ctx, state.MemberTeams, plan.MemberTeams, &resp.Diagnostics)
+	removedTeams, err := util.ValidateUUIDDiff(ctx, state.MemberTeams, plan.MemberTeams, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 	}

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -2,7 +2,6 @@ package teams
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	otypes "github.com/deepmap/oapi-codegen/pkg/types"
@@ -147,23 +146,23 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 // addInitialMembers adds the members specified in the plan to a newly created team.
 // Returns false if the caller should return due to an error.
 func (r *teamResource) addInitialMembers(ctx context.Context, diags *diag.Diagnostics, id otypes.UUID, plan TeamResourceModel) bool {
-	planMemberUsers := setToStringSlice(ctx, plan.MemberUsers, diags)
-	planMemberTeams := setToStringSlice(ctx, plan.MemberTeams, diags)
-	if diags.HasError() {
-		return false
-	}
+	emptyStrings := types.SetNull(types.StringType)
 
-	memberEmails, err := validateAndMapUserEmails(planMemberUsers)
+	memberEmails, err := util.ValidateAndMapUserEmails(ctx, plan.MemberUsers, emptyStrings, diags)
 	if err != nil {
 		diags.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 
 		return false
 	}
 
-	teamIDs, err := util.ParseUUIDList(planMemberTeams)
+	teamIDs, err := util.ParseUUIDSets(ctx, plan.MemberTeams, emptyStrings, diags)
 	if err != nil {
 		diags.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 
+		return false
+	}
+
+	if diags.HasError() {
 		return false
 	}
 
@@ -274,58 +273,27 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) (*[]string, *[]string, *[]otypes.UUID, *[]otypes.UUID) {
-	planUsers := setToStringSlice(ctx, plan.MemberUsers, &resp.Diagnostics)
-	stateUsers := setToStringSlice(ctx, state.MemberUsers, &resp.Diagnostics)
-	planTeams := setToStringSlice(ctx, plan.MemberTeams, &resp.Diagnostics)
-	stateTeams := setToStringSlice(ctx, state.MemberTeams, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return nil, nil, nil, nil
-	}
-
-	addedUsers, err := validateAndMapUserEmails(util.SubtractListValues(planUsers, stateUsers))
+	addedUsers, err := util.ValidateAndMapUserEmails(ctx, plan.MemberUsers, state.MemberUsers, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 	}
 
-	removedUsers, err := validateAndMapUserEmails(util.SubtractListValues(stateUsers, planUsers))
+	removedUsers, err := util.ValidateAndMapUserEmails(ctx, state.MemberUsers, plan.MemberUsers, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 	}
 
-	addedTeams, err := util.ParseUUIDList(util.SubtractListValues(planTeams, stateTeams))
+	addedTeams, err := util.ParseUUIDSets(ctx, plan.MemberTeams, state.MemberTeams, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 	}
 
-	removedTeams, err := util.ParseUUIDList(util.SubtractListValues(stateTeams, planTeams))
+	removedTeams, err := util.ParseUUIDSets(ctx, state.MemberTeams, plan.MemberTeams, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 	}
 
 	return addedUsers, removedUsers, addedTeams, removedTeams
-}
-
-func setToStringSlice(ctx context.Context, s types.Set, diags *diag.Diagnostics) []types.String {
-	if s.IsNull() || s.IsUnknown() {
-		return nil
-	}
-
-	result := make([]types.String, 0, len(s.Elements()))
-	diags.Append(s.ElementsAs(ctx, &result, false)...)
-
-	return result
-}
-
-func validateAndMapUserEmails(emails []types.String) (*[]string, error) {
-	validEmails := make([]string, 0, len(emails))
-	for _, email := range emails {
-		if !util.IsValidEmail(email.ValueString()) {
-			return nil, fmt.Errorf("invalid email address: %s", email.ValueString())
-		}
-		validEmails = append(validEmails, email.ValueString())
-	}
-
-	return &validEmails, nil
 }
 
 func (r *teamResource) shouldUpdate(state, plan TeamResourceModel, addedUsers, removedUsers *[]string, addedTeams, removedTeams *[]otypes.UUID) bool {

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -366,34 +366,36 @@ func toTeamResourceModel(team management.Team) TeamResourceModel {
 
 func toUsersEmailSet(userList *[]management.UserInfo) types.Set {
 	if userList == nil {
-		set, _ := types.SetValue(types.StringType, []attr.Value{})
-
-		return set
+		return types.SetValueMust(types.StringType, []attr.Value{})
 	}
 
-	elems := make([]attr.Value, len(*userList))
-	for i, user := range *userList {
-		elems[i] = types.StringValue(user.Email)
+	seen := make(map[string]struct{}, len(*userList))
+	elems := make([]attr.Value, 0, len(*userList))
+	for _, user := range *userList {
+		if _, ok := seen[user.Email]; ok {
+			continue
+		}
+		seen[user.Email] = struct{}{}
+		elems = append(elems, types.StringValue(user.Email))
 	}
 
-	set, _ := types.SetValue(types.StringType, elems)
-
-	return set
+	return types.SetValueMust(types.StringType, elems)
 }
 
 func toTeamsUUIDSet(teamList *[]management.TeamInfo) types.Set {
 	if teamList == nil {
-		set, _ := types.SetValue(types.StringType, []attr.Value{})
-
-		return set
+		return types.SetValueMust(types.StringType, []attr.Value{})
 	}
 
-	elems := make([]attr.Value, len(*teamList))
-	for i, t := range *teamList {
-		elems[i] = util.UUIDStringValue(t.TeamID)
+	seen := make(map[otypes.UUID]struct{}, len(*teamList))
+	elems := make([]attr.Value, 0, len(*teamList))
+	for _, t := range *teamList {
+		if _, ok := seen[t.TeamID]; ok {
+			continue
+		}
+		seen[t.TeamID] = struct{}{}
+		elems = append(elems, util.UUIDStringValue(t.TeamID))
 	}
 
-	set, _ := types.SetValue(types.StringType, elems)
-
-	return set
+	return types.SetValueMust(types.StringType, elems)
 }

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -166,7 +166,7 @@ func (r *teamResource) addInitialMembers(ctx context.Context, diags *diag.Diagno
 		return false
 	}
 
-	if (memberEmails == nil || len(*memberEmails) == 0) && teamIDs == nil {
+	if (memberEmails == nil || len(*memberEmails) == 0) && (teamIDs == nil || len(*teamIDs) == 0) {
 		return true
 	}
 

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -236,12 +236,12 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	id := uuid.MustParse(state.ID.ValueString())
 
-	addedUsers, removedUsers, addedTeams, removedTeams := r.parseUserAndTeamIds(ctx, resp, state, plan)
+	addedUsers, removedUsers, addedTeams, removedTeams := parseUserAndTeamIds(ctx, resp, state, plan)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if r.shouldUpdate(state, plan, addedUsers, removedUsers, addedTeams, removedTeams) {
+	if shouldUpdate(state, plan, addedUsers, removedUsers, addedTeams, removedTeams) {
 		teamPatchResponse, err := r.PatchV1TeamsTeamIDWithResponse(ctx, id, management.PatchV1TeamsTeamIDJSONRequestBody{
 			Name:                   util.MaybeString(plan.Name),
 			Description:            util.MaybeString(plan.Description),
@@ -272,7 +272,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) ([]string, []string, []otypes.UUID, []otypes.UUID) {
+func parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) ([]string, []string, []otypes.UUID, []otypes.UUID) {
 	addedUsers, err := util.ValidateUserEmailDiff(ctx, plan.MemberUsers, state.MemberUsers, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
@@ -296,7 +296,7 @@ func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.U
 	return addedUsers, removedUsers, addedTeams, removedTeams
 }
 
-func (r *teamResource) shouldUpdate(state, plan TeamResourceModel, addedUsers, removedUsers []string, addedTeams, removedTeams []otypes.UUID) bool {
+func shouldUpdate(state, plan TeamResourceModel, addedUsers, removedUsers []string, addedTeams, removedTeams []otypes.UUID) bool {
 	return len(addedUsers) > 0 || len(removedUsers) > 0 || len(addedTeams) > 0 || len(removedTeams) > 0 || plan.Name != state.Name || plan.Description != state.Description
 }
 

--- a/internal/provider/teams/resource.go
+++ b/internal/provider/teams/resource.go
@@ -8,11 +8,12 @@ import (
 	otypes "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/singlestore-labs/singlestore-go/management"
@@ -31,12 +32,12 @@ var (
 )
 
 type TeamResourceModel struct {
-	ID          types.String   `tfsdk:"id"`
-	Name        types.String   `tfsdk:"name"`
-	Description types.String   `tfsdk:"description"`
-	MemberUsers []types.String `tfsdk:"member_users"`
-	MemberTeams []types.String `tfsdk:"member_teams"`
-	CreatedAt   types.String   `tfsdk:"created_at"`
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	MemberUsers types.Set    `tfsdk:"member_users"`
+	MemberTeams types.Set    `tfsdk:"member_teams"`
+	CreatedAt   types.String `tfsdk:"created_at"`
 }
 
 // teamResource is the resource implementation.
@@ -56,9 +57,9 @@ func (r *teamResource) Metadata(_ context.Context, req resource.MetadataRequest,
 
 // Schema defines the schema for the resource.
 func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	emptyList, _ := types.ListValue(types.StringType, []attr.Value{})
+	emptySet, _ := types.SetValue(types.StringType, []attr.Value{})
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage SingleStoreDB teams with this resource. The 'apply' action creates a new team or updates an existing one. You can add/remove users to/from the team by specifying their email addresses in the 'member_users' list. You can also add/remove other teams to/from this team by specifying their IDs in the 'member_teams' list. The 'destroy' action deletes the team. Updating the 'member_users' or 'member_teams' lists will add or remove the corresponding users or teams from the team.",
+		MarkdownDescription: "Manage SingleStoreDB teams with this resource. The 'apply' action creates a new team or updates an existing one. You can add/remove users to/from the team by specifying their email addresses in the 'member_users' set. You can also add/remove other teams to/from this team by specifying their IDs in the 'member_teams' set. The 'destroy' action deletes the team. Updating the 'member_users' or 'member_teams' sets will add or remove the corresponding users or teams from the team.",
 		Attributes: map[string]schema.Attribute{
 			config.IDAttribute: schema.StringAttribute{
 				PlanModifiers: []planmodifier.String{
@@ -75,19 +76,19 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Optional:            true,
 				MarkdownDescription: "The description of the team.",
 			},
-			"member_users": schema.ListAttribute{
+			"member_users": schema.SetAttribute{
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
-				Default:             listdefault.StaticValue(emptyList),
-				MarkdownDescription: "List of user emails that are members of this team.",
+				Default:             setdefault.StaticValue(emptySet),
+				MarkdownDescription: "Set of user emails that are members of this team.",
 			},
-			"member_teams": schema.ListAttribute{
+			"member_teams": schema.SetAttribute{
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
-				Default:             listdefault.StaticValue(emptyList),
-				MarkdownDescription: "List of team UUIDs that are members of this team.",
+				Default:             setdefault.StaticValue(emptySet),
+				MarkdownDescription: "Set of team UUIDs that are members of this team.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
@@ -122,45 +123,8 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	id := teamCreateResponse.JSON200.TeamID
 
-	memberEmails, err := validateAndMapUserEmails(plan.MemberUsers)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("member_users"),
-			"Invalid user email",
-			err.Error(),
-		)
-
+	if !r.addInitialMembers(ctx, &resp.Diagnostics, id, plan) {
 		return
-	}
-
-	teamIDs, err := util.ParseUUIDList(plan.MemberTeams)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("member_teams"),
-			"Invalid team ID",
-			err.Error(),
-		)
-
-		return
-	}
-
-	if (memberEmails != nil && len(*memberEmails) > 0) || teamIDs != nil {
-		teamPatchResponse, err := r.PatchV1TeamsTeamIDWithResponse(ctx,
-			id,
-			management.PatchV1TeamsTeamIDJSONRequestBody{
-				AddMemberUserEmails: memberEmails,
-				AddMemberTeamIDs:    teamIDs,
-			},
-		)
-
-		if serr := util.StatusOK(teamPatchResponse, err); serr != nil {
-			resp.Diagnostics.AddError(
-				serr.Summary,
-				serr.Detail,
-			)
-
-			return
-		}
 	}
 
 	team, err := r.GetV1TeamsTeamIDWithResponse(ctx, id)
@@ -178,6 +142,46 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
+}
+
+// addInitialMembers adds the members specified in the plan to a newly created team.
+// Returns false if the caller should return due to an error.
+func (r *teamResource) addInitialMembers(ctx context.Context, diags *diag.Diagnostics, id otypes.UUID, plan TeamResourceModel) bool {
+	planMemberUsers := setToStringSlice(ctx, plan.MemberUsers, diags)
+	planMemberTeams := setToStringSlice(ctx, plan.MemberTeams, diags)
+	if diags.HasError() {
+		return false
+	}
+
+	memberEmails, err := validateAndMapUserEmails(planMemberUsers)
+	if err != nil {
+		diags.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
+
+		return false
+	}
+
+	teamIDs, err := util.ParseUUIDList(planMemberTeams)
+	if err != nil {
+		diags.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
+
+		return false
+	}
+
+	if (memberEmails == nil || len(*memberEmails) == 0) && teamIDs == nil {
+		return true
+	}
+
+	teamPatchResponse, err := r.PatchV1TeamsTeamIDWithResponse(ctx, id, management.PatchV1TeamsTeamIDJSONRequestBody{
+		AddMemberUserEmails: memberEmails,
+		AddMemberTeamIDs:    teamIDs,
+	})
+	if serr := util.StatusOK(teamPatchResponse, err); serr != nil {
+		diags.AddError(serr.Summary, serr.Detail)
+
+		return false
+	}
+
+	return true
 }
 
 // Read refreshes the Terraform state with the latest data.
@@ -233,7 +237,7 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	id := uuid.MustParse(state.ID.ValueString())
 
-	addedUsers, removedUsers, addedTeams, removedTeams := r.parseUserAndTeamIds(resp, state, plan)
+	addedUsers, removedUsers, addedTeams, removedTeams := r.parseUserAndTeamIds(ctx, resp, state, plan)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -269,28 +273,47 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func (r *teamResource) parseUserAndTeamIds(resp *resource.UpdateResponse, state, plan TeamResourceModel) (*[]string, *[]string, *[]otypes.UUID, *[]otypes.UUID) {
-	addedUsers, err := validateAndMapUserEmails(util.SubtractListValues(plan.MemberUsers, state.MemberUsers))
+func (r *teamResource) parseUserAndTeamIds(ctx context.Context, resp *resource.UpdateResponse, state, plan TeamResourceModel) (*[]string, *[]string, *[]otypes.UUID, *[]otypes.UUID) {
+	planUsers := setToStringSlice(ctx, plan.MemberUsers, &resp.Diagnostics)
+	stateUsers := setToStringSlice(ctx, state.MemberUsers, &resp.Diagnostics)
+	planTeams := setToStringSlice(ctx, plan.MemberTeams, &resp.Diagnostics)
+	stateTeams := setToStringSlice(ctx, state.MemberTeams, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return nil, nil, nil, nil
+	}
+
+	addedUsers, err := validateAndMapUserEmails(util.SubtractListValues(planUsers, stateUsers))
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 	}
 
-	removedUsers, err := validateAndMapUserEmails(util.SubtractListValues(state.MemberUsers, plan.MemberUsers))
+	removedUsers, err := validateAndMapUserEmails(util.SubtractListValues(stateUsers, planUsers))
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_users"), "Invalid user email", err.Error())
 	}
 
-	addedTeams, err := util.ParseUUIDList(util.SubtractListValues(plan.MemberTeams, state.MemberTeams))
+	addedTeams, err := util.ParseUUIDList(util.SubtractListValues(planTeams, stateTeams))
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 	}
 
-	removedTeams, err := util.ParseUUIDList(util.SubtractListValues(state.MemberTeams, plan.MemberTeams))
+	removedTeams, err := util.ParseUUIDList(util.SubtractListValues(stateTeams, planTeams))
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("member_teams"), "Invalid team ID", err.Error())
 	}
 
 	return addedUsers, removedUsers, addedTeams, removedTeams
+}
+
+func setToStringSlice(ctx context.Context, s types.Set, diags *diag.Diagnostics) []types.String {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+
+	result := make([]types.String, 0, len(s.Elements()))
+	diags.Append(s.ElementsAs(ctx, &result, false)...)
+
+	return result
 }
 
 func validateAndMapUserEmails(emails []types.String) (*[]string, error) {
@@ -368,33 +391,41 @@ func toTeamResourceModel(team management.Team) TeamResourceModel {
 		Name:        types.StringValue(team.Name),
 		Description: types.StringValue(team.Description),
 		CreatedAt:   util.MaybeStringValue(team.CreatedAt),
-		MemberUsers: toUsersEmailList(team.MemberUsers),
-		MemberTeams: toTeamsUUIDList(team.MemberTeams),
+		MemberUsers: toUsersEmailSet(team.MemberUsers),
+		MemberTeams: toTeamsUUIDSet(team.MemberTeams),
 	}
 }
 
-func toUsersEmailList(userList *[]management.UserInfo) []types.String {
+func toUsersEmailSet(userList *[]management.UserInfo) types.Set {
 	if userList == nil {
-		return []types.String{}
+		set, _ := types.SetValue(types.StringType, []attr.Value{})
+
+		return set
 	}
 
-	users := make([]types.String, len(*userList))
+	elems := make([]attr.Value, len(*userList))
 	for i, user := range *userList {
-		users[i] = types.StringValue(user.Email)
+		elems[i] = types.StringValue(user.Email)
 	}
 
-	return users
+	set, _ := types.SetValue(types.StringType, elems)
+
+	return set
 }
 
-func toTeamsUUIDList(userList *[]management.TeamInfo) []types.String {
-	if userList == nil {
-		return []types.String{}
+func toTeamsUUIDSet(teamList *[]management.TeamInfo) types.Set {
+	if teamList == nil {
+		set, _ := types.SetValue(types.StringType, []attr.Value{})
+
+		return set
 	}
 
-	users := make([]types.String, len(*userList))
-	for i, user := range *userList {
-		users[i] = util.UUIDStringValue(user.TeamID)
+	elems := make([]attr.Value, len(*teamList))
+	for i, t := range *teamList {
+		elems[i] = util.UUIDStringValue(t.TeamID)
 	}
 
-	return users
+	set, _ := types.SetValue(types.StringType, elems)
+
+	return set
 }

--- a/internal/provider/teams/resource_internal_test.go
+++ b/internal/provider/teams/resource_internal_test.go
@@ -1,0 +1,42 @@
+package teams
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/singlestore-labs/singlestore-go/management"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToUsersEmailSet_Deduplicates(t *testing.T) {
+	users := []management.UserInfo{
+		{Email: "alice@example.com"},
+		{Email: "alice@example.com"},
+		{Email: "bob@example.com"},
+	}
+
+	set := toUsersEmailSet(&users)
+	require.False(t, set.IsNull())
+	require.False(t, set.IsUnknown())
+	require.Equal(t, 2, len(set.Elements()))
+	require.Contains(t, set.Elements(), types.StringValue("alice@example.com"))
+	require.Contains(t, set.Elements(), types.StringValue("bob@example.com"))
+}
+
+func TestToTeamsUUIDSet_Deduplicates(t *testing.T) {
+	id1 := uuid.MustParse("9966fccf-5116-437e-a34f-008ee32e8d94")
+	id2 := uuid.MustParse("458d14e6-fcc4-4985-a2a6-f1f1f15cef2f")
+	teams := []management.TeamInfo{
+		{TeamID: id1},
+		{TeamID: id1},
+		{TeamID: id2},
+	}
+
+	set := toTeamsUUIDSet(&teams)
+	require.False(t, set.IsNull())
+	require.False(t, set.IsUnknown())
+	require.Equal(t, 2, len(set.Elements()))
+	require.Contains(t, set.Elements(), types.StringValue(id1.String()))
+	require.Contains(t, set.Elements(), types.StringValue(id2.String()))
+}

--- a/internal/provider/teams/resource_test.go
+++ b/internal/provider/teams/resource_test.go
@@ -169,8 +169,8 @@ func TestCRUDTeam(t *testing.T) {
 				Config: testutil.UpdatableConfig(examples.TeamsResource).
 					WithTeamResource("this")("name", cty.StringVal(nameUpdate)).
 					WithTeamResource("this")("description", cty.StringVal(descriptionUpdate)).
-					WithTeamResource("this")("member_users", cty.ListVal([]cty.Value{cty.StringVal(testUserMember.Email)})).
-					WithTeamResource("this")("member_teams", cty.ListVal([]cty.Value{cty.StringVal(testTeamMember.TeamID.String())})).
+					WithTeamResource("this")("member_users", cty.SetVal([]cty.Value{cty.StringVal(testUserMember.Email)})).
+					WithTeamResource("this")("member_teams", cty.SetVal([]cty.Value{cty.StringVal(testTeamMember.TeamID.String())})).
 					String(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("singlestoredb_team.this", config.IDAttribute, team.TeamID.String()),
@@ -178,8 +178,8 @@ func TestCRUDTeam(t *testing.T) {
 					resource.TestCheckResourceAttr("singlestoredb_team.this", "description", descriptionUpdate),
 					resource.TestCheckResourceAttr("singlestoredb_team.this", "member_teams.#", "1"),
 					resource.TestCheckResourceAttr("singlestoredb_team.this", "member_users.#", "1"),
-					resource.TestCheckResourceAttr("singlestoredb_team.this", "member_users.0", testUserMember.Email),
-					resource.TestCheckResourceAttr("singlestoredb_team.this", "member_teams.0", testTeamMember.TeamID.String()),
+					resource.TestCheckTypeSetElemAttr("singlestoredb_team.this", "member_users.*", testUserMember.Email),
+					resource.TestCheckTypeSetElemAttr("singlestoredb_team.this", "member_teams.*", testTeamMember.TeamID.String()),
 				),
 			},
 		},

--- a/internal/provider/util/converters.go
+++ b/internal/provider/util/converters.go
@@ -1,12 +1,14 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	otypes "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/singlestore-labs/singlestore-go/management"
 )
@@ -243,4 +245,74 @@ func ParseUUIDList(list []types.String) (*[]otypes.UUID, error) {
 	}
 
 	return uuids, nil
+}
+
+// ParseUUIDSets computes the set difference (a - b) of UUID string sets and
+// parses each resulting value into a UUID. It returns a pointer to the parsed
+// UUIDs, or nil if the difference is empty (matching ParseUUIDList semantics).
+// This avoids materializing an intermediate list between the set-difference
+// and UUID-parsing steps.
+func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) (*[]otypes.UUID, error) {
+	var uuids *[]otypes.UUID
+	if a.IsNull() || a.IsUnknown() {
+		return uuids, nil
+	}
+
+	bSet := make(map[string]struct{}, len(b.Elements()))
+	if !b.IsNull() && !b.IsUnknown() {
+		bElems := make([]types.String, 0, len(b.Elements()))
+		diags.Append(b.ElementsAs(ctx, &bElems, false)...)
+		for _, v := range bElems {
+			bSet[v.ValueString()] = struct{}{}
+		}
+	}
+
+	for _, v := range a.Elements() {
+		id := v.(types.String).ValueString()
+		if _, exists := bSet[id]; exists {
+			continue
+		}
+		teamID, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("invalid UUID: %w", err)
+		}
+		if uuids == nil {
+			values := make([]otypes.UUID, 0, len(a.Elements()))
+			uuids = &values
+		}
+		*uuids = append(*uuids, teamID)
+	}
+
+	return uuids, nil
+}
+
+// ValidateAndMapUserEmails computes the set difference (a - b) of email
+// sets and validates each resulting email, returning the validated emails or an
+// error if any email is invalid.
+func ValidateAndMapUserEmails(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) (*[]string, error) {
+	validEmails := make([]string, 0, len(a.Elements()))
+	if a.IsNull() || a.IsUnknown() {
+		return &validEmails, nil
+	}
+	bSet := make(map[string]struct{}, len(b.Elements()))
+	if !b.IsNull() && !b.IsUnknown() {
+		bElems := make([]types.String, 0, len(b.Elements()))
+		diags.Append(b.ElementsAs(ctx, &bElems, false)...)
+		for _, v := range bElems {
+			bSet[v.ValueString()] = struct{}{}
+		}
+	}
+
+	for _, v := range a.Elements() {
+		email := v.(types.String).ValueString()
+		if _, exists := bSet[email]; exists {
+			continue
+		}
+		if !IsValidEmail(email) {
+			return nil, fmt.Errorf("invalid email address: %s", email)
+		}
+		validEmails = append(validEmails, email)
+	}
+
+	return &validEmails, nil
 }

--- a/internal/provider/util/converters.go
+++ b/internal/provider/util/converters.go
@@ -230,32 +230,13 @@ func StringValueOrNull[T ~string](value *T) types.String {
 	return types.StringValue(string(*value))
 }
 
-func ParseUUIDList(list []types.String) (*[]otypes.UUID, error) {
-	var uuids *[]otypes.UUID
-	if len(list) > 0 {
-		values := make([]otypes.UUID, 0, len(list))
-		uuids = &values
-		for _, id := range list {
-			teamID, err := uuid.Parse(id.ValueString())
-			if err != nil {
-				return nil, fmt.Errorf("invalid UUID: %w", err)
-			}
-			*uuids = append(*uuids, teamID)
-		}
-	}
-
-	return uuids, nil
-}
-
 // ParseUUIDSets computes the set difference (a - b) of UUID string sets and
-// parses each resulting value into a UUID. It returns a pointer to the parsed
-// UUIDs, or nil if the difference is empty (matching ParseUUIDList semantics).
-// This avoids materializing an intermediate list between the set-difference
-// and UUID-parsing steps.
+// parses each resulting value into a UUID. Returns a pointer to the parsed
+// UUIDs, or pointer to an empty slice if the difference is empty.
 func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) (*[]otypes.UUID, error) {
-	var uuids *[]otypes.UUID
+	uuids := make([]otypes.UUID, 0, len(a.Elements()))
 	if a.IsNull() || a.IsUnknown() {
-		return uuids, nil
+		return &uuids, nil
 	}
 
 	bSet := make(map[string]struct{}, len(b.Elements()))
@@ -276,14 +257,10 @@ func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics)
 		if err != nil {
 			return nil, fmt.Errorf("invalid UUID: %w", err)
 		}
-		if uuids == nil {
-			values := make([]otypes.UUID, 0, len(a.Elements()))
-			uuids = &values
-		}
-		*uuids = append(*uuids, teamID)
+		uuids = append(uuids, teamID)
 	}
 
-	return uuids, nil
+	return &uuids, nil
 }
 
 // ValidateAndMapUserEmails computes the set difference (a - b) of email

--- a/internal/provider/util/converters.go
+++ b/internal/provider/util/converters.go
@@ -260,7 +260,7 @@ func SetDifference(ctx context.Context, a, b types.Set, diags *diag.Diagnostics)
 
 // ValidateSet applies convert to each element in a, returning the mapped values or the first
 // conversion error encountered.
-func ValidateSet[T any](ctx context.Context, a []string, diags *diag.Diagnostics, convert func(string) (T, error)) ([]T, error) {
+func ValidateSet[T any](a []string, convert func(string) (T, error)) ([]T, error) {
 	result := make([]T, 0, len(a))
 	for _, elem := range a {
 		v, err := convert(elem)
@@ -278,7 +278,7 @@ func ValidateSet[T any](ctx context.Context, a []string, diags *diag.Diagnostics
 func ValidateUUIDDiff(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]otypes.UUID, error) {
 	diff := SetDifference(ctx, a, b, diags)
 
-	return ValidateSet(ctx, diff, diags, uuid.Parse)
+	return ValidateSet(diff, uuid.Parse)
 }
 
 // ValidateUserEmailDiff computes the set difference (a - b) of email sets and
@@ -287,5 +287,5 @@ func ValidateUUIDDiff(ctx context.Context, a, b types.Set, diags *diag.Diagnosti
 func ValidateUserEmailDiff(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]string, error) {
 	diff := SetDifference(ctx, a, b, diags)
 
-	return ValidateSet(ctx, diff, diags, IsValidEmail)
+	return ValidateSet(diff, IsValidEmail)
 }

--- a/internal/provider/util/converters.go
+++ b/internal/provider/util/converters.go
@@ -230,66 +230,62 @@ func StringValueOrNull[T ~string](value *T) types.String {
 	return types.StringValue(string(*value))
 }
 
-// ParseUUIDSets computes the set difference (a - b) of UUID string sets and
-// parses each resulting value into a UUID. Returns a pointer to the parsed
-// UUIDs, or pointer to an empty slice if the difference is empty.
-func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]otypes.UUID, error) {
-	uuids := make([]otypes.UUID, 0, len(a.Elements()))
+// SetDifference computes the set difference (a - b) of two string sets.
+// Null or unknown a yields an empty result; null or unknown b is treated as empty.
+func SetDifference(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) []string {
 	if a.IsNull() || a.IsUnknown() {
-		return uuids, nil
+		return []string{}
 	}
 
 	bSet := make(map[string]struct{}, len(b.Elements()))
 	if !b.IsNull() && !b.IsUnknown() {
 		bElems := make([]types.String, 0, len(b.Elements()))
 		diags.Append(b.ElementsAs(ctx, &bElems, false)...)
-		for _, v := range bElems {
-			bSet[v.ValueString()] = struct{}{}
+		for _, bElem := range bElems {
+			bSet[bElem.ValueString()] = struct{}{}
 		}
 	}
 
-	for _, v := range a.Elements() {
-		id := v.(types.String).ValueString()
-		if _, exists := bSet[id]; exists {
+	result := make([]string, 0, len(a.Elements()))
+	for _, aElem := range a.Elements() {
+		s := aElem.(types.String).ValueString()
+		if _, exists := bSet[s]; exists {
 			continue
 		}
-		teamID, err := uuid.Parse(id)
-		if err != nil {
-			return []otypes.UUID{}, fmt.Errorf("invalid UUID: %w", err)
-		}
-		uuids = append(uuids, teamID)
+		result = append(result, s)
 	}
 
-	return uuids, nil
+	return result
 }
 
-// ValidateAndMapUserEmails computes the set difference (a - b) of email
-// sets and validates each resulting email, returning the validated emails or an
-// error if any email is invalid.
-func ValidateAndMapUserEmails(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]string, error) {
-	validEmails := make([]string, 0, len(a.Elements()))
-	if a.IsNull() || a.IsUnknown() {
-		return validEmails, nil
-	}
-	bSet := make(map[string]struct{}, len(b.Elements()))
-	if !b.IsNull() && !b.IsUnknown() {
-		bElems := make([]types.String, 0, len(b.Elements()))
-		diags.Append(b.ElementsAs(ctx, &bElems, false)...)
-		for _, v := range bElems {
-			bSet[v.ValueString()] = struct{}{}
+// ValidateSet applies convert to each element in a, returning the mapped values or the first
+// conversion error encountered.
+func ValidateSet[T any](ctx context.Context, a []string, diags *diag.Diagnostics, convert func(string) (T, error)) ([]T, error) {
+	result := make([]T, 0, len(a))
+	for _, elem := range a {
+		v, err := convert(elem)
+		if err != nil {
+			return []T{}, err
 		}
+		result = append(result, v)
 	}
 
-	for _, v := range a.Elements() {
-		email := v.(types.String).ValueString()
-		if _, exists := bSet[email]; exists {
-			continue
-		}
-		if !IsValidEmail(email) {
-			return []string{}, fmt.Errorf("invalid email address: %s", email)
-		}
-		validEmails = append(validEmails, email)
-	}
+	return result, nil
+}
 
-	return validEmails, nil
+// ValidateUUIDDiff computes the set difference (a - b) of UUID string sets and
+// parses each resulting value into a UUID, returning the parsed UUIDs or the first parsing error encountered.
+func ValidateUUIDDiff(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]otypes.UUID, error) {
+	diff := SetDifference(ctx, a, b, diags)
+
+	return ValidateSet(ctx, diff, diags, uuid.Parse)
+}
+
+// ValidateUserEmailDiff computes the set difference (a - b) of email sets and
+// validates each resulting email, returning the validated emails or the first
+// validation error encountered.
+func ValidateUserEmailDiff(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]string, error) {
+	diff := SetDifference(ctx, a, b, diags)
+
+	return ValidateSet(ctx, diff, diags, IsValidEmail)
 }

--- a/internal/provider/util/converters.go
+++ b/internal/provider/util/converters.go
@@ -233,10 +233,10 @@ func StringValueOrNull[T ~string](value *T) types.String {
 // ParseUUIDSets computes the set difference (a - b) of UUID string sets and
 // parses each resulting value into a UUID. Returns a pointer to the parsed
 // UUIDs, or pointer to an empty slice if the difference is empty.
-func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) (*[]otypes.UUID, error) {
+func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]otypes.UUID, error) {
 	uuids := make([]otypes.UUID, 0, len(a.Elements()))
 	if a.IsNull() || a.IsUnknown() {
-		return &uuids, nil
+		return uuids, nil
 	}
 
 	bSet := make(map[string]struct{}, len(b.Elements()))
@@ -255,21 +255,21 @@ func ParseUUIDSets(ctx context.Context, a, b types.Set, diags *diag.Diagnostics)
 		}
 		teamID, err := uuid.Parse(id)
 		if err != nil {
-			return nil, fmt.Errorf("invalid UUID: %w", err)
+			return []otypes.UUID{}, fmt.Errorf("invalid UUID: %w", err)
 		}
 		uuids = append(uuids, teamID)
 	}
 
-	return &uuids, nil
+	return uuids, nil
 }
 
 // ValidateAndMapUserEmails computes the set difference (a - b) of email
 // sets and validates each resulting email, returning the validated emails or an
 // error if any email is invalid.
-func ValidateAndMapUserEmails(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) (*[]string, error) {
+func ValidateAndMapUserEmails(ctx context.Context, a, b types.Set, diags *diag.Diagnostics) ([]string, error) {
 	validEmails := make([]string, 0, len(a.Elements()))
 	if a.IsNull() || a.IsUnknown() {
-		return &validEmails, nil
+		return validEmails, nil
 	}
 	bSet := make(map[string]struct{}, len(b.Elements()))
 	if !b.IsNull() && !b.IsUnknown() {
@@ -286,10 +286,10 @@ func ValidateAndMapUserEmails(ctx context.Context, a, b types.Set, diags *diag.D
 			continue
 		}
 		if !IsValidEmail(email) {
-			return nil, fmt.Errorf("invalid email address: %s", email)
+			return []string{}, fmt.Errorf("invalid email address: %s", email)
 		}
 		validEmails = append(validEmails, email)
 	}
 
-	return &validEmails, nil
+	return validEmails, nil
 }

--- a/internal/provider/util/converters_test.go
+++ b/internal/provider/util/converters_test.go
@@ -127,7 +127,7 @@ func TestParseUUIDSets_AllNew(t *testing.T) {
 	a := mustUUIDSet(t, testUUID1, testUUID2)
 	b := mustUUIDSet(t)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(testUUID1), uuid.MustParse(testUUID2)}, got)
@@ -140,7 +140,7 @@ func TestParseUUIDSets_DifferenceFiltersOverlap(t *testing.T) {
 	a := mustUUIDSet(t, testUUID1, testUUID2, testUUID3)
 	b := mustUUIDSet(t, testUUID2)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(testUUID1), uuid.MustParse(testUUID3)}, got)
@@ -153,7 +153,7 @@ func TestParseUUIDSets_FullOverlapReturnsEmpty(t *testing.T) {
 	a := mustUUIDSet(t, testUUID1, testUUID2)
 	b := mustUUIDSet(t, testUUID1, testUUID2)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Empty(t, got)
@@ -166,7 +166,7 @@ func TestParseUUIDSets_EmptyAReturnsEmpty(t *testing.T) {
 	a := mustUUIDSet(t)
 	b := mustUUIDSet(t, testUUID1)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Empty(t, got)
@@ -179,7 +179,7 @@ func TestParseUUIDSets_ANullReturnsEmpty(t *testing.T) {
 	a := types.SetNull(types.StringType)
 	b := mustUUIDSet(t)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Empty(t, got)
@@ -192,7 +192,7 @@ func TestParseUUIDSets_AUnknownReturnsEmpty(t *testing.T) {
 	a := types.SetUnknown(types.StringType)
 	b := mustUUIDSet(t)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Empty(t, got)
@@ -205,7 +205,7 @@ func TestParseUUIDSets_BNullTreatedAsEmpty(t *testing.T) {
 	a := mustUUIDSet(t, testUUID1)
 	b := types.SetNull(types.StringType)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
@@ -218,7 +218,7 @@ func TestParseUUIDSets_BUnknownTreatedAsEmpty(t *testing.T) {
 	a := mustUUIDSet(t, testUUID1)
 	b := types.SetUnknown(types.StringType)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
@@ -231,7 +231,7 @@ func TestParseUUIDSets_InvalidUUIDReturnsError(t *testing.T) {
 	a := mustUUIDSet(t, testUUID1, invalidUUID)
 	b := mustUUIDSet(t)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.Error(t, err)
 	require.Empty(t, got)
 	require.Contains(t, err.Error(), "invalid UUID")
@@ -246,7 +246,7 @@ func TestParseUUIDSets_InvalidUUIDIgnoredWhenInB(t *testing.T) {
 	a := mustUUIDSet(t, invalidUUID, testUUID1)
 	b := mustUUIDSet(t, invalidUUID)
 
-	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	got, err := util.ValidateUUIDDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
@@ -259,7 +259,7 @@ func TestValidateAndMapUserEmails_AllNew(t *testing.T) {
 	a := mustEmailSet(t, testEmail1, testEmail2)
 	b := mustEmailSet(t)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.ElementsMatch(t, []string{testEmail1, testEmail2}, got)
@@ -272,7 +272,7 @@ func TestValidateAndMapUserEmails_DifferenceFiltersOverlap(t *testing.T) {
 	a := mustEmailSet(t, testEmail1, testEmail2, testEmail3)
 	b := mustEmailSet(t, testEmail2)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.ElementsMatch(t, []string{testEmail1, testEmail3}, got)
@@ -285,7 +285,7 @@ func TestValidateAndMapUserEmails_FullOverlapReturnsEmpty(t *testing.T) {
 	a := mustEmailSet(t, testEmail1, testEmail2)
 	b := mustEmailSet(t, testEmail1, testEmail2)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Empty(t, got)
@@ -298,7 +298,7 @@ func TestValidateAndMapUserEmails_EmptyAReturnsEmpty(t *testing.T) {
 	a := mustEmailSet(t)
 	b := mustEmailSet(t, testEmail2)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Empty(t, got)
@@ -311,7 +311,7 @@ func TestValidateAndMapUserEmails_BNullTreatedAsEmpty(t *testing.T) {
 	a := mustEmailSet(t, testEmail1)
 	b := types.SetNull(types.StringType)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Equal(t, []string{testEmail1}, got)
@@ -324,7 +324,7 @@ func TestValidateAndMapUserEmails_BUnknownTreatedAsEmpty(t *testing.T) {
 	a := mustEmailSet(t, testEmail1)
 	b := types.SetUnknown(types.StringType)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Equal(t, []string{testEmail1}, got)
@@ -337,7 +337,7 @@ func TestValidateAndMapUserEmails_InvalidEmailReturnsError(t *testing.T) {
 	a := mustEmailSet(t, testEmail1, invalidEmail)
 	b := mustEmailSet(t)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.Error(t, err)
 	require.Empty(t, got)
 	require.Contains(t, err.Error(), "invalid email address")
@@ -353,7 +353,7 @@ func TestValidateAndMapUserEmails_InvalidEmailIgnoredWhenInB(t *testing.T) {
 	a := mustEmailSet(t, invalidEmail, testEmail1)
 	b := mustEmailSet(t, invalidEmail)
 
-	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	got, err := util.ValidateUserEmailDiff(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
 	require.Equal(t, []string{testEmail1}, got)

--- a/internal/provider/util/converters_test.go
+++ b/internal/provider/util/converters_test.go
@@ -1,9 +1,13 @@
 package util_test
 
 import (
+	"context"
 	"testing"
 
+	otypes "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/singlestore-labs/singlestore-go/management"
 	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/util"
@@ -42,7 +46,7 @@ func TestMaybeBoolValue(t *testing.T) {
 }
 
 func TestUUIDStringValue(t *testing.T) {
-	id := "9966fccf-5116-437e-a34f-008ee32e8d94"
+	id := "9966fccf-5116-437e-a34f-008ee32e8d94" //nolint:goconst // test ID
 	require.Equal(t, types.StringValue(id), util.UUIDStringValue(uuid.MustParse(id)))
 }
 
@@ -76,4 +80,303 @@ func TestWorkspaceStateString(t *testing.T) {
 func TestWorkspaceStateStringValue(t *testing.T) {
 	state := management.WorkspaceStateACTIVE
 	require.Equal(t, string(state), util.WorkspaceStateStringValue(state).ValueString())
+}
+
+func mustUUIDSet(t *testing.T, ids ...string) types.Set {
+	t.Helper()
+
+	elems := make([]attr.Value, len(ids))
+	for i, id := range ids {
+		elems[i] = types.StringValue(id)
+	}
+
+	set, diags := types.SetValue(types.StringType, elems)
+	require.False(t, diags.HasError(), "failed to build UUID set: %s", diags)
+
+	return set
+}
+
+func mustEmailSet(t *testing.T, emails ...string) types.Set {
+	t.Helper()
+
+	elems := make([]attr.Value, len(emails))
+	for i, e := range emails {
+		elems[i] = types.StringValue(e)
+	}
+
+	set, diags := types.SetValue(types.StringType, elems)
+	require.False(t, diags.HasError(), "failed to build email set: %s", diags)
+
+	return set
+}
+
+func TestParseUUIDSets_AllNew(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+	id2 := "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f" //nolint:goconst
+
+	a := mustUUIDSet(t, id1, id2)
+	b := mustUUIDSet(t)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(id1), uuid.MustParse(id2)}, *got)
+}
+
+func TestParseUUIDSets_DifferenceFiltersOverlap(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+	id2 := "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"
+	id3 := "283d4b0d-b0d6-485a-bc2d-a763c523c68a"
+
+	a := mustUUIDSet(t, id1, id2, id3)
+	b := mustUUIDSet(t, id2)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(id1), uuid.MustParse(id3)}, *got)
+}
+
+func TestParseUUIDSets_FullOverlapReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+	id2 := "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"
+
+	a := mustUUIDSet(t, id1, id2)
+	b := mustUUIDSet(t, id1, id2)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.Nil(t, got, "expected nil to match ParseUUIDList semantics for empty difference")
+}
+
+func TestParseUUIDSets_EmptyAReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+
+	a := mustUUIDSet(t)
+	b := mustUUIDSet(t, id1)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.Nil(t, got)
+}
+
+func TestParseUUIDSets_ANullReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := types.SetNull(types.StringType)
+	b := mustUUIDSet(t)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.Nil(t, got)
+}
+
+func TestParseUUIDSets_AUnknownReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := types.SetUnknown(types.StringType)
+	b := mustUUIDSet(t)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.Nil(t, got)
+}
+
+func TestParseUUIDSets_BNullTreatedAsEmpty(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+
+	a := mustUUIDSet(t, id1)
+	b := types.SetNull(types.StringType)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Equal(t, []otypes.UUID{uuid.MustParse(id1)}, *got)
+}
+
+func TestParseUUIDSets_BUnknownTreatedAsEmpty(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+
+	a := mustUUIDSet(t, id1)
+	b := types.SetUnknown(types.StringType)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Equal(t, []otypes.UUID{uuid.MustParse(id1)}, *got)
+}
+
+func TestParseUUIDSets_InvalidUUIDReturnsError(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+
+	a := mustUUIDSet(t, id1, "not-a-uuid")
+	b := mustUUIDSet(t)
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "invalid UUID")
+}
+
+func TestParseUUIDSets_InvalidUUIDIgnoredWhenInB(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
+
+	// Malformed UUIDs in a should be skipped (not parsed) when present in b,
+	// because they are being filtered out of the set difference.
+	a := mustUUIDSet(t, "not-a-uuid", id1)
+	b := mustUUIDSet(t, "not-a-uuid")
+
+	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Equal(t, []otypes.UUID{uuid.MustParse(id1)}, *got)
+}
+
+func TestValidateAndMapUserEmails_AllNew(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t, "alice@example.com", "bob@example.com")
+	b := mustEmailSet(t)
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.ElementsMatch(t, []string{"alice@example.com", "bob@example.com"}, *got)
+}
+
+func TestValidateAndMapUserEmails_DifferenceFiltersOverlap(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t, "alice@example.com", "bob@example.com", "carol@example.com")
+	b := mustEmailSet(t, "bob@example.com")
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.ElementsMatch(t, []string{"alice@example.com", "carol@example.com"}, *got)
+}
+
+func TestValidateAndMapUserEmails_FullOverlapReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t, "alice@example.com", "bob@example.com")
+	b := mustEmailSet(t, "alice@example.com", "bob@example.com")
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Empty(t, *got)
+}
+
+func TestValidateAndMapUserEmails_EmptyAReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t)
+	b := mustEmailSet(t, "bob@example.com")
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Empty(t, *got)
+}
+
+func TestValidateAndMapUserEmails_BNullTreatedAsEmpty(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t, "alice@example.com")
+	b := types.SetNull(types.StringType)
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Equal(t, []string{"alice@example.com"}, *got)
+}
+
+func TestValidateAndMapUserEmails_BUnknownTreatedAsEmpty(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t, "alice@example.com")
+	b := types.SetUnknown(types.StringType)
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Equal(t, []string{"alice@example.com"}, *got)
+}
+
+func TestValidateAndMapUserEmails_InvalidEmailReturnsError(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	a := mustEmailSet(t, "alice@example.com", "not-an-email")
+	b := mustEmailSet(t)
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "invalid email address")
+	require.Contains(t, err.Error(), "not-an-email")
+}
+
+func TestValidateAndMapUserEmails_InvalidEmailIgnoredWhenInB(t *testing.T) {
+	ctx := context.Background()
+	diags := diag.Diagnostics{}
+
+	// Even if the email is malformed, it should be skipped (not validated)
+	// when present in b, because it is being filtered out of the difference.
+	a := mustEmailSet(t, "not-an-email", "alice@example.com")
+	b := mustEmailSet(t, "not-an-email")
+
+	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
+	require.NoError(t, err)
+	require.False(t, diags.HasError())
+	require.NotNil(t, got)
+	require.Equal(t, []string{"alice@example.com"}, *got)
 }

--- a/internal/provider/util/converters_test.go
+++ b/internal/provider/util/converters_test.go
@@ -145,7 +145,7 @@ func TestParseUUIDSets_DifferenceFiltersOverlap(t *testing.T) {
 	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(id1), uuid.MustParse(id3)}, *got)
 }
 
-func TestParseUUIDSets_FullOverlapReturnsNil(t *testing.T) {
+func TestParseUUIDSets_FullOverlapReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -158,10 +158,11 @@ func TestParseUUIDSets_FullOverlapReturnsNil(t *testing.T) {
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.Nil(t, got, "expected nil to match ParseUUIDList semantics for empty difference")
+	require.NotNil(t, got)
+	require.Empty(t, *got)
 }
 
-func TestParseUUIDSets_EmptyAReturnsNil(t *testing.T) {
+func TestParseUUIDSets_EmptyAReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -173,10 +174,11 @@ func TestParseUUIDSets_EmptyAReturnsNil(t *testing.T) {
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.Nil(t, got)
+	require.NotNil(t, got)
+	require.Empty(t, *got)
 }
 
-func TestParseUUIDSets_ANullReturnsNil(t *testing.T) {
+func TestParseUUIDSets_ANullReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -186,10 +188,11 @@ func TestParseUUIDSets_ANullReturnsNil(t *testing.T) {
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.Nil(t, got)
+	require.NotNil(t, got)
+	require.Empty(t, *got)
 }
 
-func TestParseUUIDSets_AUnknownReturnsNil(t *testing.T) {
+func TestParseUUIDSets_AUnknownReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -199,7 +202,8 @@ func TestParseUUIDSets_AUnknownReturnsNil(t *testing.T) {
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.Nil(t, got)
+	require.NotNil(t, got)
+	require.Empty(t, *got)
 }
 
 func TestParseUUIDSets_BNullTreatedAsEmpty(t *testing.T) {

--- a/internal/provider/util/converters_test.go
+++ b/internal/provider/util/converters_test.go
@@ -120,7 +120,7 @@ func mustEmailSet(t *testing.T, emails ...string) types.Set {
 	return set
 }
 
-func TestParseUUIDSets_AllNew(t *testing.T) {
+func TestValidateUUIDDiff_AllNew(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -133,7 +133,7 @@ func TestParseUUIDSets_AllNew(t *testing.T) {
 	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(testUUID1), uuid.MustParse(testUUID2)}, got)
 }
 
-func TestParseUUIDSets_DifferenceFiltersOverlap(t *testing.T) {
+func TestValidateUUIDDiff_DifferenceFiltersOverlap(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -146,7 +146,7 @@ func TestParseUUIDSets_DifferenceFiltersOverlap(t *testing.T) {
 	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(testUUID1), uuid.MustParse(testUUID3)}, got)
 }
 
-func TestParseUUIDSets_FullOverlapReturnsEmpty(t *testing.T) {
+func TestValidateUUIDDiff_FullOverlapReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -159,7 +159,7 @@ func TestParseUUIDSets_FullOverlapReturnsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestParseUUIDSets_EmptyAReturnsEmpty(t *testing.T) {
+func TestValidateUUIDDiff_EmptyAReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -172,7 +172,7 @@ func TestParseUUIDSets_EmptyAReturnsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestParseUUIDSets_ANullReturnsEmpty(t *testing.T) {
+func TestValidateUUIDDiff_ANullReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -185,7 +185,7 @@ func TestParseUUIDSets_ANullReturnsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestParseUUIDSets_AUnknownReturnsEmpty(t *testing.T) {
+func TestValidateUUIDDiff_AUnknownReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -198,7 +198,7 @@ func TestParseUUIDSets_AUnknownReturnsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestParseUUIDSets_BNullTreatedAsEmpty(t *testing.T) {
+func TestValidateUUIDDiff_BNullTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -211,7 +211,7 @@ func TestParseUUIDSets_BNullTreatedAsEmpty(t *testing.T) {
 	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
 }
 
-func TestParseUUIDSets_BUnknownTreatedAsEmpty(t *testing.T) {
+func TestValidateUUIDDiff_BUnknownTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -224,7 +224,7 @@ func TestParseUUIDSets_BUnknownTreatedAsEmpty(t *testing.T) {
 	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
 }
 
-func TestParseUUIDSets_InvalidUUIDReturnsError(t *testing.T) {
+func TestValidateUUIDDiff_InvalidUUIDReturnsError(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -237,7 +237,7 @@ func TestParseUUIDSets_InvalidUUIDReturnsError(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid UUID")
 }
 
-func TestParseUUIDSets_InvalidUUIDIgnoredWhenInB(t *testing.T) {
+func TestValidateUUIDDiff_InvalidUUIDIgnoredWhenInB(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -252,7 +252,7 @@ func TestParseUUIDSets_InvalidUUIDIgnoredWhenInB(t *testing.T) {
 	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
 }
 
-func TestValidateAndMapUserEmails_AllNew(t *testing.T) {
+func TestValidateUserEmailDiff_AllNew(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -265,7 +265,7 @@ func TestValidateAndMapUserEmails_AllNew(t *testing.T) {
 	require.ElementsMatch(t, []string{testEmail1, testEmail2}, got)
 }
 
-func TestValidateAndMapUserEmails_DifferenceFiltersOverlap(t *testing.T) {
+func TestValidateUserEmailDiff_DifferenceFiltersOverlap(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -278,7 +278,7 @@ func TestValidateAndMapUserEmails_DifferenceFiltersOverlap(t *testing.T) {
 	require.ElementsMatch(t, []string{testEmail1, testEmail3}, got)
 }
 
-func TestValidateAndMapUserEmails_FullOverlapReturnsEmpty(t *testing.T) {
+func TestValidateUserEmailDiff_FullOverlapReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -291,7 +291,7 @@ func TestValidateAndMapUserEmails_FullOverlapReturnsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestValidateAndMapUserEmails_EmptyAReturnsEmpty(t *testing.T) {
+func TestValidateUserEmailDiff_EmptyAReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -304,7 +304,7 @@ func TestValidateAndMapUserEmails_EmptyAReturnsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestValidateAndMapUserEmails_BNullTreatedAsEmpty(t *testing.T) {
+func TestValidateUserEmailDiff_BNullTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -317,7 +317,7 @@ func TestValidateAndMapUserEmails_BNullTreatedAsEmpty(t *testing.T) {
 	require.Equal(t, []string{testEmail1}, got)
 }
 
-func TestValidateAndMapUserEmails_BUnknownTreatedAsEmpty(t *testing.T) {
+func TestValidateUserEmailDiff_BUnknownTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -330,7 +330,7 @@ func TestValidateAndMapUserEmails_BUnknownTreatedAsEmpty(t *testing.T) {
 	require.Equal(t, []string{testEmail1}, got)
 }
 
-func TestValidateAndMapUserEmails_InvalidEmailReturnsError(t *testing.T) {
+func TestValidateUserEmailDiff_InvalidEmailReturnsError(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
@@ -344,7 +344,7 @@ func TestValidateAndMapUserEmails_InvalidEmailReturnsError(t *testing.T) {
 	require.Contains(t, err.Error(), invalidEmail)
 }
 
-func TestValidateAndMapUserEmails_InvalidEmailIgnoredWhenInB(t *testing.T) {
+func TestValidateUserEmailDiff_InvalidEmailIgnoredWhenInB(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 

--- a/internal/provider/util/converters_test.go
+++ b/internal/provider/util/converters_test.go
@@ -14,6 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testUUID1    = "9966fccf-5116-437e-a34f-008ee32e8d94"
+	testUUID2    = "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"
+	testUUID3    = "283d4b0d-b0d6-485a-bc2d-a763c523c68a"
+	testEmail1   = "alice@example.com"
+	testEmail2   = "bob@example.com"
+	testEmail3   = "carol@example.com"
+	invalidUUID  = "not-a-uuid"
+	invalidEmail = "not-an-email"
+)
+
 func TestMaybeString(t *testing.T) {
 	require.Nil(t, util.MaybeString(types.StringNull()))
 	require.Nil(t, util.MaybeString(types.StringUnknown()))
@@ -46,8 +57,7 @@ func TestMaybeBoolValue(t *testing.T) {
 }
 
 func TestUUIDStringValue(t *testing.T) {
-	id := "9966fccf-5116-437e-a34f-008ee32e8d94" //nolint:goconst // test ID
-	require.Equal(t, types.StringValue(id), util.UUIDStringValue(uuid.MustParse(id)))
+	require.Equal(t, types.StringValue(testUUID1), util.UUIDStringValue(uuid.MustParse(testUUID1)))
 }
 
 func TestStringFirewallRanges(t *testing.T) {
@@ -91,7 +101,7 @@ func mustUUIDSet(t *testing.T, ids ...string) types.Set {
 	}
 
 	set, diags := types.SetValue(types.StringType, elems)
-	require.False(t, diags.HasError(), "failed to build UUID set: %s", diags)
+	require.False(t, diags.HasError(), "failed to build UUID set: %v", diags)
 
 	return set
 }
@@ -105,7 +115,7 @@ func mustEmailSet(t *testing.T, emails ...string) types.Set {
 	}
 
 	set, diags := types.SetValue(types.StringType, elems)
-	require.False(t, diags.HasError(), "failed to build email set: %s", diags)
+	require.False(t, diags.HasError(), "failed to build email set: %v", diags)
 
 	return set
 }
@@ -114,68 +124,52 @@ func TestParseUUIDSets_AllNew(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-	id2 := "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f" //nolint:goconst
-
-	a := mustUUIDSet(t, id1, id2)
+	a := mustUUIDSet(t, testUUID1, testUUID2)
 	b := mustUUIDSet(t)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(id1), uuid.MustParse(id2)}, *got)
+	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(testUUID1), uuid.MustParse(testUUID2)}, got)
 }
 
 func TestParseUUIDSets_DifferenceFiltersOverlap(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-	id2 := "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"
-	id3 := "283d4b0d-b0d6-485a-bc2d-a763c523c68a"
-
-	a := mustUUIDSet(t, id1, id2, id3)
-	b := mustUUIDSet(t, id2)
+	a := mustUUIDSet(t, testUUID1, testUUID2, testUUID3)
+	b := mustUUIDSet(t, testUUID2)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(id1), uuid.MustParse(id3)}, *got)
+	require.ElementsMatch(t, []otypes.UUID{uuid.MustParse(testUUID1), uuid.MustParse(testUUID3)}, got)
 }
 
 func TestParseUUIDSets_FullOverlapReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-	id2 := "458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"
-
-	a := mustUUIDSet(t, id1, id2)
-	b := mustUUIDSet(t, id1, id2)
+	a := mustUUIDSet(t, testUUID1, testUUID2)
+	b := mustUUIDSet(t, testUUID1, testUUID2)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Empty(t, *got)
+	require.Empty(t, got)
 }
 
 func TestParseUUIDSets_EmptyAReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-
 	a := mustUUIDSet(t)
-	b := mustUUIDSet(t, id1)
+	b := mustUUIDSet(t, testUUID1)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Empty(t, *got)
+	require.Empty(t, got)
 }
 
 func TestParseUUIDSets_ANullReturnsEmpty(t *testing.T) {
@@ -188,8 +182,7 @@ func TestParseUUIDSets_ANullReturnsEmpty(t *testing.T) {
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Empty(t, *got)
+	require.Empty(t, got)
 }
 
 func TestParseUUIDSets_AUnknownReturnsEmpty(t *testing.T) {
@@ -202,54 +195,45 @@ func TestParseUUIDSets_AUnknownReturnsEmpty(t *testing.T) {
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Empty(t, *got)
+	require.Empty(t, got)
 }
 
 func TestParseUUIDSets_BNullTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-
-	a := mustUUIDSet(t, id1)
+	a := mustUUIDSet(t, testUUID1)
 	b := types.SetNull(types.StringType)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Equal(t, []otypes.UUID{uuid.MustParse(id1)}, *got)
+	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
 }
 
 func TestParseUUIDSets_BUnknownTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-
-	a := mustUUIDSet(t, id1)
+	a := mustUUIDSet(t, testUUID1)
 	b := types.SetUnknown(types.StringType)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Equal(t, []otypes.UUID{uuid.MustParse(id1)}, *got)
+	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
 }
 
 func TestParseUUIDSets_InvalidUUIDReturnsError(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-
-	a := mustUUIDSet(t, id1, "not-a-uuid")
+	a := mustUUIDSet(t, testUUID1, invalidUUID)
 	b := mustUUIDSet(t)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.Error(t, err)
-	require.Nil(t, got)
+	require.Empty(t, got)
 	require.Contains(t, err.Error(), "invalid UUID")
 }
 
@@ -257,60 +241,54 @@ func TestParseUUIDSets_InvalidUUIDIgnoredWhenInB(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	id1 := "9966fccf-5116-437e-a34f-008ee32e8d94"
-
 	// Malformed UUIDs in a should be skipped (not parsed) when present in b,
 	// because they are being filtered out of the set difference.
-	a := mustUUIDSet(t, "not-a-uuid", id1)
-	b := mustUUIDSet(t, "not-a-uuid")
+	a := mustUUIDSet(t, invalidUUID, testUUID1)
+	b := mustUUIDSet(t, invalidUUID)
 
 	got, err := util.ParseUUIDSets(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Equal(t, []otypes.UUID{uuid.MustParse(id1)}, *got)
+	require.Equal(t, []otypes.UUID{uuid.MustParse(testUUID1)}, got)
 }
 
 func TestValidateAndMapUserEmails_AllNew(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	a := mustEmailSet(t, "alice@example.com", "bob@example.com")
+	a := mustEmailSet(t, testEmail1, testEmail2)
 	b := mustEmailSet(t)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.ElementsMatch(t, []string{"alice@example.com", "bob@example.com"}, *got)
+	require.ElementsMatch(t, []string{testEmail1, testEmail2}, got)
 }
 
 func TestValidateAndMapUserEmails_DifferenceFiltersOverlap(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	a := mustEmailSet(t, "alice@example.com", "bob@example.com", "carol@example.com")
-	b := mustEmailSet(t, "bob@example.com")
+	a := mustEmailSet(t, testEmail1, testEmail2, testEmail3)
+	b := mustEmailSet(t, testEmail2)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.ElementsMatch(t, []string{"alice@example.com", "carol@example.com"}, *got)
+	require.ElementsMatch(t, []string{testEmail1, testEmail3}, got)
 }
 
 func TestValidateAndMapUserEmails_FullOverlapReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	a := mustEmailSet(t, "alice@example.com", "bob@example.com")
-	b := mustEmailSet(t, "alice@example.com", "bob@example.com")
+	a := mustEmailSet(t, testEmail1, testEmail2)
+	b := mustEmailSet(t, testEmail1, testEmail2)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Empty(t, *got)
+	require.Empty(t, got)
 }
 
 func TestValidateAndMapUserEmails_EmptyAReturnsEmpty(t *testing.T) {
@@ -318,55 +296,52 @@ func TestValidateAndMapUserEmails_EmptyAReturnsEmpty(t *testing.T) {
 	diags := diag.Diagnostics{}
 
 	a := mustEmailSet(t)
-	b := mustEmailSet(t, "bob@example.com")
+	b := mustEmailSet(t, testEmail2)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Empty(t, *got)
+	require.Empty(t, got)
 }
 
 func TestValidateAndMapUserEmails_BNullTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	a := mustEmailSet(t, "alice@example.com")
+	a := mustEmailSet(t, testEmail1)
 	b := types.SetNull(types.StringType)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Equal(t, []string{"alice@example.com"}, *got)
+	require.Equal(t, []string{testEmail1}, got)
 }
 
 func TestValidateAndMapUserEmails_BUnknownTreatedAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	a := mustEmailSet(t, "alice@example.com")
+	a := mustEmailSet(t, testEmail1)
 	b := types.SetUnknown(types.StringType)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Equal(t, []string{"alice@example.com"}, *got)
+	require.Equal(t, []string{testEmail1}, got)
 }
 
 func TestValidateAndMapUserEmails_InvalidEmailReturnsError(t *testing.T) {
 	ctx := context.Background()
 	diags := diag.Diagnostics{}
 
-	a := mustEmailSet(t, "alice@example.com", "not-an-email")
+	a := mustEmailSet(t, testEmail1, invalidEmail)
 	b := mustEmailSet(t)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.Error(t, err)
-	require.Nil(t, got)
+	require.Empty(t, got)
 	require.Contains(t, err.Error(), "invalid email address")
-	require.Contains(t, err.Error(), "not-an-email")
+	require.Contains(t, err.Error(), invalidEmail)
 }
 
 func TestValidateAndMapUserEmails_InvalidEmailIgnoredWhenInB(t *testing.T) {
@@ -375,12 +350,11 @@ func TestValidateAndMapUserEmails_InvalidEmailIgnoredWhenInB(t *testing.T) {
 
 	// Even if the email is malformed, it should be skipped (not validated)
 	// when present in b, because it is being filtered out of the difference.
-	a := mustEmailSet(t, "not-an-email", "alice@example.com")
-	b := mustEmailSet(t, "not-an-email")
+	a := mustEmailSet(t, invalidEmail, testEmail1)
+	b := mustEmailSet(t, invalidEmail)
 
 	got, err := util.ValidateAndMapUserEmails(ctx, a, b, &diags)
 	require.NoError(t, err)
 	require.False(t, diags.HasError())
-	require.NotNil(t, got)
-	require.Equal(t, []string{"alice@example.com"}, *got)
+	require.Equal(t, []string{testEmail1}, got)
 }

--- a/internal/provider/util/util.go
+++ b/internal/provider/util/util.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
 )
 
@@ -166,22 +165,6 @@ func ReadNotEmptyFileTrimmed(path string) (string, error) {
 	}
 
 	return result, nil
-}
-
-func SubtractListValues(a, b []types.String) []types.String {
-	bSet := make(map[string]struct{})
-	for _, v := range b {
-		bSet[v.ValueString()] = struct{}{}
-	}
-
-	var result []types.String
-	for _, v := range a {
-		if _, exists := bSet[v.ValueString()]; !exists {
-			result = append(result, v)
-		}
-	}
-
-	return result
 }
 
 func IsValidEmail(email string) bool {

--- a/internal/provider/util/util.go
+++ b/internal/provider/util/util.go
@@ -167,10 +167,12 @@ func ReadNotEmptyFileTrimmed(path string) (string, error) {
 	return result, nil
 }
 
-func IsValidEmail(email string) bool {
-	_, err := mail.ParseAddress(email)
+func IsValidEmail(email string) (string, error) {
+	if _, err := mail.ParseAddress(email); err != nil {
+		return "", fmt.Errorf("invalid email address: %s", email)
+	}
 
-	return err == nil
+	return email, nil
 }
 
 // ImportStatePassthroughID validates the import ID is a valid UUID before passing it through.
@@ -185,14 +187,4 @@ func ImportStatePassthroughID(ctx context.Context, req resource.ImportStateReque
 	}
 
 	resource.ImportStatePassthroughID(ctx, path.Root(config.IDAttribute), req, resp)
-}
-
-func ValidateEmails(emails []string) error {
-	for _, email := range emails {
-		if !IsValidEmail(email) {
-			return fmt.Errorf("invalid email address: %s", email)
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Terraform schema/state shape for `singlestoredb_team` membership fields from lists to sets, which can cause state diffs/migrations and different update behavior for existing configs.
> 
> **Overview**
> Updates `singlestoredb_team` so `member_users` and `member_teams` are **sets instead of lists**, including schema defaults and docs, to avoid order-sensitive diffs.
> 
> Refactors create/update membership handling to compute *set differences* and validate/parse entries via new util helpers (`ValidateAndMapUserEmails`, `ParseUUIDSets`), adds an `addInitialMembers` helper for post-create patching, and updates tests to assert set semantics. Also adds generated docs for the `singlestoredb_project` resource.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fb70b88ff104dda7ad34eceed36773d9c5f8b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->