### PR TITLE
chore: prepare for release 0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.1.15 - 2026-04-28
+
 ### Added
 
 - New `singlestoredb_project` resource with generated documentation (#100, #102).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Releases are triggered automatically when a new Git tag is pushed.
 
 ## ✅ Steps to Release
 
-### 1. Review Changes
+### 1. Review Changes and update the change log
 
 List version tags (newest first):
 
@@ -20,6 +20,10 @@ Show commits since the last release (example for v0.3.2):
 ```bash
 git log v0.3.2..HEAD --oneline
 ```
+
+Make sure that `CHANGELOG.md` "Unreleased" section has been updated with new features and bug fixes and security updates, optionally with other changes. If some commits are missing - update `CHANGELOG.md` accordingly.
+
+Select a new version, add a new section under "Unreleased", e.g. "## v0.1.15 - 2026-04-28"
 
 ### 2. Tag and Push
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to the changelog and release process instructions; no runtime code or infrastructure behavior changes.
> 
> **Overview**
> Prepares the `v0.1.15` release by adding a new `CHANGELOG.md` section dated `2026-04-28` and moving the listed additions/changes/build/dependency notes under that version.
> 
> Updates `RELEASING.md` to explicitly require updating the `CHANGELOG.md` *Unreleased* section and creating a new version header before tagging a release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857d4530828ca14e71f1e6acbe0e10ae6f4a5b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->