### PR TITLE
chore: prepare for release 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.1.16 - 2026-05-18
+
+### Fixed
+
+- Fixed a bug where workspace group update resulted in empty password being sent in a patch request, so users were getting the error "password must contain at least 14 characters" (#108).
+
+
 ## v0.1.15 - 2026-04-28
 
 ### Added


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating `CHANGELOG.md` with release notes; no runtime code is modified.
> 
> **Overview**
> Adds a `v0.1.16` section to `CHANGELOG.md` dated 2026-05-18, documenting a fix for workspace group updates that previously sent an empty password in PATCH requests (triggering a minimum-length validation error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1fa23ac2dd0e07f2357d86b0bd95327f3a168d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->