### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Active maintainers: @pmishchenko-ua @noprysk-ua @filipelsilva @tiagoacastro
+
+# Default owners — fall-through for anything not matched below.
+*                                               @pmishchenko-ua @noprysk-ua
+
+/internal/provider/flow/                        @filipelsilva
+/examples/resources/singlestoredb_flow/         @filipelsilva
+/examples/data-sources/singlestoredb_flow/      @filipelsilva
+/examples/data-sources/singlestoredb_flows/     @filipelsilva
+
+/internal/provider/projects/                    @tiagoacastro
+/examples/resources/singlestoredb_project/      @tiagoacastro
+/examples/data-sources/singlestoredb_projects/  @tiagoacastro


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds repository ownership rules only; no runtime code or behavior changes.
> 
> **Overview**
> Introduces a new `CODEOWNERS` file to define default code ownership and route reviews for `internal/provider/flow` and `internal/provider/projects` (plus related examples) to specific maintainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7daee5892edeeb3c53c28f55cb9b0f717674f9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->