### PR TITLE
Fix Flow endpoint readiness error text

### DIFF
--- a/internal/provider/flow/wait.go
+++ b/internal/provider/flow/wait.go
@@ -90,7 +90,7 @@ func waitConditionReady() waitCondition {
 				return fmt.Errorf("flow instance %s database name is not yet available", f.FlowID)
 			}
 
-			return fmt.Errorf("flow instance %s endpoint is not yet ready", f.FlowID)
+			return fmt.Errorf("flow instance %s endpoint is not yet available", f.FlowID)
 		}
 
 		if !util.CheckLastN(readinessHistory, config.FlowInstanceConsistencyThreshold, true) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Align empty Flow endpoint readiness errors with the `endpoint is not yet available` assertion.

### Testing
- Reproduced the reported failure with `go test ./internal/provider/flow -run 'TestWaitConditionReady/endpoint_not_available' -count=1` before the fix.
- Passed `go test ./internal/provider/flow -run 'TestWaitConditionReady/endpoint_not_available' -count=1` after the fix.
- Passed `go test ./internal/provider/flow -short -count=1` after the fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e692d0d0-8f1f-47e2-941c-6efe72e778da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e692d0d0-8f1f-47e2-941c-6efe72e778da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

