### PR TITLE
build: add option to run provider in debug mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,18 +68,9 @@ Overrides any global `go.testEnvFile` setting so debug sessions load credentials
 
 ### `.vscode/private.env`
 
-Copy from the example below and set your API key. This file is gitignored.
+Create `.vscode/private.env` (gitignored) and set your API key, for example:
 
-```shell
-cp .vscode/private.env.example .vscode/private.env
-```
-
-`.vscode/private.env.example`:
-
-```
-# Copy to private.env for the "Debug Terraform Provider" launch config.
-# SINGLESTOREDB_API_KEY=your-api-key
-```
+    echo 'SINGLESTOREDB_API_KEY=your-api-key' > .vscode/private.env
 
 ### `.vscode/launch.json`
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,100 @@ Try out any example in the [examples](examples) directory!
 
 Please note that `terraform init` is not compatible with `dev_overrides`, so run `terraform plan` directly.
 
+## Debugging
+
+The provider supports interactive debugging with [Delve](https://github.com/go-delve/delve) via VS Code or Cursor. The `main` function accepts a `-debug` flag that enables the Terraform reattach protocol.
+
+Install the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go), then create a local `.vscode/` directory (gitignored) with the files below.
+
+### `.vscode/extensions.json`
+
+```json
+{
+  "recommendations": ["golang.go"]
+}
+```
+
+### `.vscode/settings.json`
+
+Overrides any global `go.testEnvFile` setting so debug sessions load credentials from this repo instead of a missing file on your machine.
+
+```json
+{
+  "go.testEnvFile": "${workspaceFolder}/.vscode/private.env"
+}
+```
+
+### `.vscode/private.env`
+
+Copy from the example below and set your API key. This file is gitignored.
+
+```shell
+cp .vscode/private.env.example .vscode/private.env
+```
+
+`.vscode/private.env.example`:
+
+```
+# Copy to private.env for the "Debug Terraform Provider" launch config.
+# SINGLESTOREDB_API_KEY=your-api-key
+```
+
+### `.vscode/launch.json`
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Terraform Provider",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}",
+      "args": ["-debug"],
+      "showLog": true,
+      "envFile": "${workspaceFolder}/.vscode/private.env"
+    },
+    {
+      "name": "Debug Unit Tests (short)",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceFolder}",
+      "args": ["-test.v", "-test.short"]
+    },
+    {
+      "name": "Debug Current Package Tests",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}",
+      "args": ["-test.v", "-test.short"]
+    }
+  ]
+}
+```
+
+### Debug with Terraform
+
+1. Set breakpoints in provider code (for example under `internal/provider/`).
+2. Run **Debug Terraform Provider** from the Run and Debug panel.
+3. Copy the `TF_REATTACH_PROVIDERS=...` line from the Debug Console.
+4. In a terminal, export it and run Terraform against an example:
+
+    ```shell
+    export TF_REATTACH_PROVIDERS='{"registry.terraform.io/singlestore-labs/singlestoredb":{...}}'
+    cd examples/resources/singlestoredb_workspace_group_advanced
+    terraform plan
+    ```
+
+Terraform routes provider calls to the debugger; breakpoints will halt execution.
+
+### Debug unit tests
+
+Open a `*_test.go` file, set breakpoints, and run **Debug Current Package Tests** or **Debug Unit Tests (short)**. No Terraform step is required.
+
 ## Reference
 
 - [Configuring Terraform](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#locally-install-provider-and-verify-with-terraform)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -11,10 +12,16 @@ import (
 var version = "dev" // Version is populated by goreleaser with ldflags.
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	ctx := context.Background()
 
 	opts := providerserver.ServeOpts{
 		Address: "registry.terraform.io/singlestore-labs/singlestoredb",
+		Debug:   debug,
 	}
 
 	if err := providerserver.Serve(ctx, provider.New(version), opts); err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to an opt-in `-debug` startup path and documentation; default provider behavior is unchanged.
> 
> **Overview**
> Adds **interactive provider debugging** for local development: `main` now parses a **`-debug`** flag and passes it to `providerserver.ServeOpts.Debug`, enabling Terraform's **reattach** flow when the binary is launched under Delve.
> 
> **DEVELOPMENT.md** gains a **Debugging** section with recommended Go extension setup, sample `.vscode` configs (launch, settings, private env for `SINGLESTOREDB_API_KEY`), steps to export **`TF_REATTACH_PROVIDERS`** and run `terraform plan` against an example, plus launch configs for **short unit tests**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584801516141ea2bec32dbb67a62f445068f0f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->