### PR TITLE
fix: mention credits in StatusForbidden error message

### DIFF
--- a/internal/provider/config/const.go
+++ b/internal/provider/config/const.go
@@ -103,6 +103,7 @@ var (
 		APIKeyPathAttribute,
 		EnvAPIKey,
 	)
+	CreditsErrorDetail                       = "Make sure your account has enough credits to perform this operation."
 	ContactSupportErrorDetail                = fmt.Sprintf("Contact SingleStore support %s.", SupportURL)
 	ContactSupportLaterErrorDetail           = fmt.Sprintf("If nothing changes in a few hours, contact SingleStore support %s.", SupportURL)
 	CreateProviderIssueErrorDetail           = fmt.Sprintf("Internal errror took place. Please, report the issue %s.", ProviderNewIssueURL)

--- a/internal/provider/config/const.go
+++ b/internal/provider/config/const.go
@@ -106,6 +106,6 @@ var (
 	CreditsErrorDetail                       = "Make sure your account has enough credits to perform this operation."
 	ContactSupportErrorDetail                = fmt.Sprintf("Contact SingleStore support %s.", SupportURL)
 	ContactSupportLaterErrorDetail           = fmt.Sprintf("If nothing changes in a few hours, contact SingleStore support %s.", SupportURL)
-	CreateProviderIssueErrorDetail           = fmt.Sprintf("Internal errror took place. Please, report the issue %s.", ProviderNewIssueURL)
+	CreateProviderIssueErrorDetail           = fmt.Sprintf("Internal error took place. Please, report the issue %s.", ProviderNewIssueURL)
 	CreateProviderIssueIfNotClearErrorDetail = fmt.Sprintf("If the error is not clear, please report the issue %s.", SupportURL)
 )

--- a/internal/provider/util/statuscoder.go
+++ b/internal/provider/util/statuscoder.go
@@ -36,10 +36,10 @@ func StatusOK(resp StatusCoder, ierr error,
 	}
 
 	if code != http.StatusOK {
-		detail := "An unsuccessful status code occurred when calling SingleStore API. "
+		detail := "An unsuccessful status code occurred when calling SingleStore API."
 		switch code {
 		case http.StatusUnauthorized:
-			detail += config.InvalidAPIKeyErrorDetail
+			detail += "\n" + config.InvalidAPIKeyErrorDetail
 		case http.StatusForbidden:
 			detail += "\n" + config.CreditsErrorDetail
 		}

--- a/internal/provider/util/statuscoder.go
+++ b/internal/provider/util/statuscoder.go
@@ -37,7 +37,11 @@ func StatusOK(resp StatusCoder, ierr error,
 
 	if code != http.StatusOK {
 		detail := "An unsuccessful status code occurred when calling SingleStore API. "
-		if code == http.StatusUnauthorized || code == http.StatusForbidden {
+		switch code {
+		case http.StatusUnauthorized:
+			detail += config.InvalidAPIKeyErrorDetail
+		case http.StatusForbidden:
+			detail += "\n" + config.CreditsErrorDetail + "\n"
 			detail += config.InvalidAPIKeyErrorDetail
 		}
 		detail += config.CreateProviderIssueIfNotClearErrorDetail + "\n\nSingleStore client response body: " + MaybeBody(resp)

--- a/internal/provider/util/statuscoder.go
+++ b/internal/provider/util/statuscoder.go
@@ -41,10 +41,9 @@ func StatusOK(resp StatusCoder, ierr error,
 		case http.StatusUnauthorized:
 			detail += config.InvalidAPIKeyErrorDetail
 		case http.StatusForbidden:
-			detail += "\n" + config.CreditsErrorDetail + "\n"
-			detail += config.InvalidAPIKeyErrorDetail
+			detail += "\n" + config.CreditsErrorDetail
 		}
-		detail += config.CreateProviderIssueIfNotClearErrorDetail + "\n\nSingleStore client response body: " + MaybeBody(resp)
+		detail += "\n" + config.CreateProviderIssueIfNotClearErrorDetail + "\n\nSingleStore client response body: " + MaybeBody(resp)
 
 		return &SummaryWithDetailError{
 			Summary: fmt.Sprintf("SingleStore API client returned status code %s", http.StatusText(code)),

--- a/internal/provider/util/statuscoder_test.go
+++ b/internal/provider/util/statuscoder_test.go
@@ -40,7 +40,7 @@ func TestStatusOK_StatusCodes(t *testing.T) {
 	}, nil)
 	require.NotNil(t, result)
 	require.Contains(t, result.Detail, config.CreditsErrorDetail)
-	require.Contains(t, result.Detail, config.InvalidAPIKeyErrorDetail)
+	require.NotContains(t, result.Detail, config.InvalidAPIKeyErrorDetail)
 
 	result = util.StatusOK(management.GetV1RegionsResponse{
 		HTTPResponse: &http.Response{StatusCode: http.StatusNotFound},

--- a/internal/provider/util/statuscoder_test.go
+++ b/internal/provider/util/statuscoder_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/singlestore-labs/singlestore-go/management"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/config"
 	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/util"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatusOK(t *testing.T) {
+func TestStatusOK_StatusCodes(t *testing.T) {
 	input := management.GetV1RegionsResponse{
 		Body: []byte("foo-bar-buzz-yes"),
 	}
@@ -26,6 +27,20 @@ func TestStatusOK(t *testing.T) {
 	result = util.StatusOK(nil, ierr)
 	require.NotNil(t, result)
 	require.Contains(t, result.Detail, ierr.Error())
+
+	result = util.StatusOK(management.GetV1RegionsResponse{
+		HTTPResponse: &http.Response{StatusCode: http.StatusUnauthorized},
+	}, nil)
+	require.NotNil(t, result)
+	require.Contains(t, result.Detail, config.InvalidAPIKeyErrorDetail)
+	require.NotContains(t, result.Detail, config.CreditsErrorDetail)
+
+	result = util.StatusOK(management.GetV1RegionsResponse{
+		HTTPResponse: &http.Response{StatusCode: http.StatusForbidden},
+	}, nil)
+	require.NotNil(t, result)
+	require.Contains(t, result.Detail, config.CreditsErrorDetail)
+	require.Contains(t, result.Detail, config.InvalidAPIKeyErrorDetail)
 
 	result = util.StatusOK(management.GetV1RegionsResponse{
 		HTTPResponse: &http.Response{StatusCode: http.StatusNotFound},


### PR DESCRIPTION
Fixes https://github.com/singlestore-labs/terraform-provider-singlestoredb/issues/47

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Terraform diagnostic text for non-OK HTTP status codes changes; no API or resource logic is affected.
> 
> **Overview**
> **403 responses** from the Management API now surface a dedicated credits message instead of the invalid API key guidance, which previously applied to both 401 and 403.
> 
> `util.StatusOK` maps **401** to `InvalidAPIKeyErrorDetail` and **403** to new `CreditsErrorDetail` ("Make sure your account has enough credits…"). Error detail lines are joined with newlines for readability. A typo in `CreateProviderIssueErrorDetail` ("errror" → "error") is fixed. Tests assert 401 and 403 each show the correct hint and not the other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00670d494535d0b026e7bddee6ea15f33138451b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->