### PR TITLE
fix(sql): repair drift integration test and raise unit coverage

### DIFF
--- a/internal/provider/sql/auth_test.go
+++ b/internal/provider/sql/auth_test.go
@@ -41,3 +41,12 @@ func TestPasswordForState(t *testing.T) {
 	require.True(t, sql.PasswordForStateForTest(types.StringValue("secret")).Equal(types.StringValue("secret")))
 	require.True(t, sql.PasswordForStateForTest(types.StringNull()).IsNull())
 }
+
+func TestPasswordConfiguredInPlan(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, sql.PasswordConfiguredInPlanForTest(types.StringValue("secret")))
+	require.False(t, sql.PasswordConfiguredInPlanForTest(types.StringValue("")))
+	require.False(t, sql.PasswordConfiguredInPlanForTest(types.StringNull()))
+	require.False(t, sql.PasswordConfiguredInPlanForTest(types.StringUnknown()))
+}

--- a/internal/provider/sql/errors_test.go
+++ b/internal/provider/sql/errors_test.go
@@ -90,3 +90,15 @@ func TestInvalidEndpointDiagnostic(t *testing.T) {
 	require.Equal(t, "Invalid workspace SQL endpoint", diag.Summary)
 	require.Equal(t, "bad endpoint", diag.Detail)
 }
+
+func TestErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	apiErr := &sql.APIError{StatusCode: 500, Body: "boom", Host: "svc.example.com"}
+	require.Equal(t, "data api error 500: boom", apiErr.Error())
+
+	require.Equal(t, "sql statement exceeds the data api 1 mb request limit", sql.RequestTooLargeError{}.Error())
+
+	queryErr := &sql.QueryError{Message: "table not found", Host: "svc.example.com"}
+	require.Equal(t, "table not found", queryErr.Error())
+}

--- a/internal/provider/sql/export_test.go
+++ b/internal/provider/sql/export_test.go
@@ -17,6 +17,11 @@ func PasswordForStateForTest(attr types.String) types.String {
 	return passwordForState(attr)
 }
 
+// PasswordConfiguredInPlanForTest exposes passwordConfiguredInPlan for external tests.
+func PasswordConfiguredInPlanForTest(attr types.String) bool {
+	return passwordConfiguredInPlan(attr)
+}
+
 // QueryDataSourceIDForTest exposes queryDataSourceID for external tests.
 func QueryDataSourceIDForTest(endpoint, query string, args []string) string {
 	return queryDataSourceID(endpoint, query, args)

--- a/internal/provider/sql/resource_test.go
+++ b/internal/provider/sql/resource_test.go
@@ -24,6 +24,9 @@ import (
 const (
 	testWorkspaceEndpoint = "workspace.example.com"
 	testAdminPassword     = "sfkjDIJ423d44w1sfooBar1$" //nolint:gosec
+
+	dataAPIExecPath  = "/api/v2/exec"
+	dataAPIQueryPath = "/api/v2/query/rows"
 )
 
 func withMockDataAPIServer(t *testing.T, handler http.Handler) {
@@ -99,7 +102,7 @@ func TestSQLExecuteCreateReadDestroy(t *testing.T) {
 		require.NoError(t, err)
 
 		switch r.URL.Path {
-		case "/api/v2/exec":
+		case dataAPIExecPath:
 			execCalls.Add(1)
 			require.Equal(t, http.MethodPost, r.Method)
 
@@ -117,7 +120,7 @@ func TestSQLExecuteCreateReadDestroy(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, err = w.Write([]byte(`{"lastInsertId":7,"rowsAffected":1}`))
 			require.NoError(t, err)
-		case "/api/v2/query/rows":
+		case dataAPIQueryPath:
 			queryCalls.Add(1)
 			require.JSONEq(t, `{"sql":"SHOW DATABASES LIKE ?","args":["my_app_db"]}`, string(body))
 
@@ -164,10 +167,10 @@ func TestSQLExecutePasswordFromEnvNotInState(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v2/exec":
+		case dataAPIExecPath:
 			_, err := w.Write([]byte(`{"lastInsertId":0,"rowsAffected":0}`))
 			require.NoError(t, err)
-		case "/api/v2/query/rows":
+		case dataAPIQueryPath:
 			_, err := w.Write([]byte(`{"results":[{"rows":[]}]}`))
 			require.NoError(t, err)
 		default:
@@ -236,6 +239,67 @@ resource "singlestoredb_sql_execute" "this" {
 			},
 		},
 	})
+}
+
+func TestSQLExecuteUpdateInPlace(t *testing.T) {
+	var execCalls atomic.Int32
+
+	withMockDataAPIServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case dataAPIExecPath:
+			execCalls.Add(1)
+			_, err := w.Write([]byte(`{"lastInsertId":0,"rowsAffected":1}`))
+			require.NoError(t, err)
+		case dataAPIQueryPath:
+			_, err := w.Write([]byte(`{"results":[{"rows":[{"Database":"my_app_db"}]}]}`))
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	configWithRevert := func(revert string) string {
+		return fmt.Sprintf(`
+provider "singlestoredb" {
+}
+
+resource "singlestoredb_sql_execute" "this" {
+  endpoint   = %q
+  username   = "admin"
+  password   = "secret"
+  execute    = "SELECT 1"
+  revert     = %q
+  query      = "SHOW DATABASES LIKE ?"
+  query_args = ["my_app_db"]
+}
+`, testWorkspaceEndpoint, revert)
+	}
+
+	testutil.UnitTest(t, testutil.UnitTestConfig{
+		APIKey: testutil.UnusedAPIKey,
+	}, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: configWithRevert("SELECT 1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("singlestoredb_sql_execute.this", "revert", "SELECT 1"),
+					resource.TestCheckResourceAttr("singlestoredb_sql_execute.this", "query_results.#", "1"),
+				),
+			},
+			{
+				Config: configWithRevert("SELECT 2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("singlestoredb_sql_execute.this", "revert", "SELECT 2"),
+					resource.TestCheckResourceAttr("singlestoredb_sql_execute.this", "query_results.#", "1"),
+					resource.TestCheckResourceAttr("singlestoredb_sql_execute.this", "query_results.0.Database", "my_app_db"),
+				),
+			},
+		},
+	})
+
+	require.Equal(t, int32(2), execCalls.Load(), "only create and destroy call /exec; in-place update must not run the execute statement")
 }
 
 func TestDataAPIRequestBodyShape(t *testing.T) {
@@ -323,7 +387,6 @@ func TestSQLExecuteDriftIntegration(t *testing.T) {
 					})
 					require.NoError(t, err)
 				},
-				Config:       integrationConfig,
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("singlestoredb_sql_execute.this", "query_results.#", "0"),

--- a/internal/provider/testutil/testutil.go
+++ b/internal/provider/testutil/testutil.go
@@ -78,7 +78,9 @@ func IntegrationTest(t *testing.T, conf IntegrationTestConfig, c resource.TestCa
 	require.NotEmpty(t, conf.APIKey, "envirnomental variable %s should be set for running integration tests", config.EnvTestAPIKey)
 
 	for i, s := range c.Steps {
-		if conf.WorkspaceGroupName != "" {
+		// Steps without a Config (e.g. RefreshState-only steps) reuse the
+		// configuration from the preceding step, so there is nothing to update.
+		if conf.WorkspaceGroupName != "" && s.Config != "" {
 			instantExpiration := time.Now().UTC().Add(config.TestWorkspaceGroupExpiration).Format(time.RFC3339)
 
 			c.Steps[i].Config = UpdatableConfig(s.Config).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `Integration` CI job for the SQL Data API client work was failing, and Codecov reported low patch coverage on the new `internal/provider/sql` package.

## What

### Integration test failure

`TestSQLExecuteDriftIntegration` failed with:

```
TestStep 2/2 validation error: TestStep cannot have Config and RefreshState
```

The terraform-plugin-sdk validates that a `TestStep` cannot set both `Config` and `RefreshState` (`helper/resource/teststep_validate.go`). A `RefreshState` step refreshes the state produced by the previous step's config, so it must not carry its own `Config`. Removed the redundant `Config` from the refresh step.

Fixing that surfaced a second bug: `testutil.IntegrationTest` injects an `expires_at` attribute into **every** step's configuration for garbage collection, but a `RefreshState`-only step has an empty `Config`, so the injection panicked (`config file should contain a block with resource singlestoredb_workspace_group.example`). Guarded the injection to skip steps without a `Config`.

Because the integration job aborted on the original failure, its coverage was never uploaded to Codecov, which deflated the reported numbers.

### Coverage

Added focused unit tests for the previously-uncovered code in the `sql` package:

- `APIError`/`RequestTooLargeError`/`QueryError` `Error()` methods.
- `passwordConfiguredInPlan`.
- The in-place `Update` path (changing `revert` triggers an update without re-running `execute`).

Extracted the Data API path literals into constants to satisfy `goconst`.

Unit coverage of `internal/provider/sql` rose from 73.1% to 79.5%, and all previously-0% functions are now exercised.

## Testing

- `TestSQLExecuteDriftIntegration` now passes end-to-end against live cloud (337.82s), provisioning a real workspace, detecting drift via `RefreshState`, and cleaning up.
- `go test -short ./internal/provider/sql/... ./internal/provider/testutil/...` passes (sql at 79.5% coverage).
- `golangci-lint run` clean on changed packages.

[drift_integration_pass.log](https://cursor.com/agents/bc-c34b77b4-c701-49eb-a398-a787c5b76b58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdrift_integration_pass.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c34b77b4-c701-49eb-a398-a787c5b76b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c34b77b4-c701-49eb-a398-a787c5b76b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

