### PR TITLE
fix(privateconnections): avoid nil pointer panic in allow_list wait condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a panic (nil pointer dereference) when updating a `singlestoredb_private_connection` and the Management API returned a private connection with a null `allow_list` while waiting for the update to converge.
+
 ## v0.1.17 - 2026-07-01
 
 ### Fixed

--- a/internal/provider/privateconnections/export_test.go
+++ b/internal/provider/privateconnections/export_test.go
@@ -1,0 +1,4 @@
+package privateconnections
+
+// WaitConditionAllowList exposes waitConditionAllowList for testing.
+var WaitConditionAllowList = waitConditionAllowList

--- a/internal/provider/privateconnections/wait.go
+++ b/internal/provider/privateconnections/wait.go
@@ -67,12 +67,7 @@ func WaitPrivateConnectionStatus(ctx context.Context, c management.ClientWithRes
 func waitConditionAllowList(desiredAllowList string) func(management.PrivateConnection) error {
 	return func(c management.PrivateConnection) error {
 		if c.AllowList == nil || *c.AllowList != desiredAllowList {
-			currentAllowList := "<nil>"
-			if c.AllowList != nil {
-				currentAllowList = *c.AllowList
-			}
-
-			return fmt.Errorf("private connection %s allow_list is %s, but should be %s", c.PrivateConnectionID, currentAllowList, desiredAllowList)
+			return fmt.Errorf("private connection %s allow_list is %s, but should be %s", c.PrivateConnectionID, util.Deref(c.AllowList), desiredAllowList)
 		}
 
 		return nil

--- a/internal/provider/privateconnections/wait.go
+++ b/internal/provider/privateconnections/wait.go
@@ -67,7 +67,12 @@ func WaitPrivateConnectionStatus(ctx context.Context, c management.ClientWithRes
 func waitConditionAllowList(desiredAllowList string) func(management.PrivateConnection) error {
 	return func(c management.PrivateConnection) error {
 		if c.AllowList == nil || *c.AllowList != desiredAllowList {
-			return fmt.Errorf("private connection %s allow_list is %s, but should be %s", c.PrivateConnectionID, *c.AllowList, desiredAllowList)
+			currentAllowList := "<nil>"
+			if c.AllowList != nil {
+				currentAllowList = *c.AllowList
+			}
+
+			return fmt.Errorf("private connection %s allow_list is %s, but should be %s", c.PrivateConnectionID, currentAllowList, desiredAllowList)
 		}
 
 		return nil

--- a/internal/provider/privateconnections/wait_test.go
+++ b/internal/provider/privateconnections/wait_test.go
@@ -1,0 +1,46 @@
+package privateconnections_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/singlestore-labs/singlestore-go/management"
+	"github.com/singlestore-labs/terraform-provider-singlestoredb/internal/provider/privateconnections"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitConditionAllowListNilAllowList(t *testing.T) {
+	condition := privateconnections.WaitConditionAllowList("301668617982")
+
+	var err error
+	require.NotPanics(t, func() {
+		err = condition(management.PrivateConnection{
+			PrivateConnectionID: uuid.MustParse("458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"),
+			AllowList:           nil,
+		})
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "should be 301668617982")
+}
+
+func TestWaitConditionAllowListMismatch(t *testing.T) {
+	condition := privateconnections.WaitConditionAllowList("301668617982")
+
+	current := "123456789012"
+	err := condition(management.PrivateConnection{
+		PrivateConnectionID: uuid.MustParse("458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"),
+		AllowList:           &current,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), current)
+}
+
+func TestWaitConditionAllowListMatch(t *testing.T) {
+	desired := "301668617982"
+	condition := privateconnections.WaitConditionAllowList(desired)
+
+	require.NoError(t, condition(management.PrivateConnection{
+		PrivateConnectionID: uuid.MustParse("458d14e6-fcc4-4985-a2a6-f1f1f15cef2f"),
+		AllowList:           &desired,
+	}))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Updating a `singlestoredb_private_connection` could crash the provider with a nil pointer dereference (`SIGSEGV`) during `ApplyResourceChange`:

```
panic: runtime error: invalid memory address or nil pointer dereference
...privateconnections.(*privateConnectionResource).Update.waitConditionAllowList.func1
    .../privateconnections/wait.go:70
```

## Root cause

In `waitConditionAllowList` (`internal/provider/privateconnections/wait.go`), the guard was:

```go
if c.AllowList == nil || *c.AllowList != desiredAllowList {
    return fmt.Errorf("... allow_list is %s ...", c.PrivateConnectionID, *c.AllowList, desiredAllowList)
}
```

When the Management API returns a private connection with a `null` `allow_list` (which happens transiently while an update converges), the condition short-circuits on `c.AllowList == nil` but the error message still dereferences `*c.AllowList`, panicking. Because this runs inside the SDK retry goroutine, the panic crashes the whole plugin instead of surfacing as a retryable error.

## Fix

Guard the dereference and render `<nil>` when `AllowList` is absent, so the wait condition returns a normal retryable error and polling continues.

## Testing

- Added `wait_test.go` covering the nil `allow_list`, mismatch, and match cases (unexported function exposed via `export_test.go`, matching the `testpackage` linter's skip pattern).
- Verified the pre-fix code panics at `wait.go:70` and the fix eliminates the panic.
- `GOTOOLCHAIN=go1.25.0 go test ./internal/provider/privateconnections/` passes (incl. the existing CRUD test).
- `golangci-lint run --fast ./internal/provider/privateconnections/` is clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-968984f6-5237-4420-9c6c-14973fd1ce51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-968984f6-5237-4420-9c6c-14973fd1ce51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

