### PR TITLE
chore: prepare for release 0.1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ terraform-provider-singlestoredb
 *.out
 .env
 **/.vscode/
+.planning/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## v0.1.18 - 2026-07-02
+
 ### Fixed
 
-- Fixed a panic (nil pointer dereference) when updating a `singlestoredb_private_connection` and the Management API returned a private connection with a null `allow_list` while waiting for the update to converge.
+- Fixed a panic (nil pointer dereference) when updating a `singlestoredb_private_connection` and the Management API returned a private connection with a null `allow_list` while waiting for the update to converge (#121).
 
 ## v0.1.17 - 2026-07-01
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and `.gitignore` only; no provider runtime or API behavior changes in this diff.
> 
> **Overview**
> Release housekeeping for **v0.1.18** (dated 2026-07-02): the changelog documents the shipped fix for a nil-pointer panic on `singlestoredb_private_connection` updates when the Management API returns a null `allow_list` during convergence wait ([#121](https://github.com/singlestore/terraform-provider-singlestoredb/pull/121)).
> 
> Also ignores the local **`.planning/`** directory in git so planning artifacts are not committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaff09ab02689b7af24fefa5fa435ffaa5f6729f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->