### PR TITLE
fix(examples): remove global-only privileges from db-scoped GRANT

### DIFF
--- a/examples/resources/singlestoredb_workspace_with_sql/resource.tf
+++ b/examples/resources/singlestoredb_workspace_with_sql/resource.tf
@@ -90,10 +90,10 @@ resource "singlestoredb_sql_execute" "grant_app_user" {
   database = local.app_db
 
   execute = <<-EOT
-    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, PROCESS, INDEX, ALTER, DROP, SHOW METADATA, CREATE DATABASE, DROP DATABASE, CREATE USER ON my_app_db.* TO 'app_user'@'%'
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, ALTER, DROP ON my_app_db.* TO 'app_user'@'%'
   EOT
   revert  = <<-EOT
-    REVOKE SELECT, INSERT, UPDATE, DELETE, CREATE, PROCESS, INDEX, ALTER, DROP, SHOW METADATA, CREATE DATABASE, DROP DATABASE, CREATE USER ON my_app_db.* FROM 'app_user'@'%'
+    REVOKE SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, ALTER, DROP ON my_app_db.* FROM 'app_user'@'%'
   EOT
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing `integration` job on #118 ([run 28675054686](https://github.com/singlestore-labs/terraform-provider-singlestoredb/actions/runs/28675054686/job/85046593919?pr=118)).

`TestWorkspaceWithSQLResourceIntegration` failed while applying the `grant_app_user` resource in the `singlestoredb_workspace_with_sql` example:

```
Error: SQL execution failed
  with singlestoredb_sql_execute.grant_app_user,
Error 1221 (HY000): Forwarding Error ...
Incorrect usage of DB GRANT: PROCESS, SHOW METADATA, CREATE USER is a global
privilege, it can be granted only on *.* and not on databases or tables
```

The example `GRANT`/`REVOKE` statements included the global-only privileges `PROCESS`, `SHOW METADATA`, and `CREATE USER` scoped to `my_app_db.*`, which SingleStore rejects. (`CREATE DATABASE`/`DROP DATABASE` were also dropped as they are not meaningful for a database-scoped application user.)

## Change

- Reduce the `grant_app_user` GRANT/REVOKE to database-scoped privileges appropriate for an application user: `SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, ALTER, DROP ON my_app_db.*`.

The example is embedded into the integration test via `go:embed`, so this directly fixes the test.

## Testing

- ✅ `go test -v -timeout=30m -run '^TestWorkspaceWithSQLResourceIntegration$' ./internal/provider/sql/` — provisioned a live workspace group + workspace, executed all SQL grants successfully, and passed: `--- PASS: TestWorkspaceWithSQLResourceIntegration (653.70s)`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-471e27bc-6d5d-4a1f-8713-b0456a8ec951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-471e27bc-6d5d-4a1f-8713-b0456a8ec951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

