### PR TITLE
fix(privateconnections): require workspace_id for OUTBOUND private connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `singlestoredb_private_connection`: require `workspace_id` for OUTBOUND connections so Terraform reports a clear validation error instead of an API error when creating a DML private link without a workspace.
+
 ### Added
 
 - New `singlestoredb_sql_execute` resource for DDL/DML against Helios workspaces via the Data API, with optional read-back for drift detection.

--- a/docs/resources/private_connection.md
+++ b/docs/resources/private_connection.md
@@ -69,7 +69,7 @@ output "private_connection_id" {
 - `sql_port` (Number) The SQL port.
 - `type` (String) The private connection type.
 - `web_socket_port` (Number) The websockets port.
-- `workspace_id` (String) The ID of the workspace to connect with.
+- `workspace_id` (String) The ID of the workspace to connect with. Required for OUTBOUND private connections (DML private link).
 
 ### Read-Only
 

--- a/internal/provider/privateconnections/privateconnectionvalidator.go
+++ b/internal/provider/privateconnections/privateconnectionvalidator.go
@@ -65,6 +65,7 @@ func getOutboundValidationRules(plan PrivateConnectionModel, isUpdate bool) []va
 		{isUpdate, "OUTBOUND private connections update is not allowed."},
 		{isDefined(plan.AllowList), "allow_list configuration is not allowed for OUTBOUND private connections."},
 		{isUndefined(plan.ServiceName), "service_name configuration is required for OUTBOUND private connections."},
+		{isUndefined(plan.WorkspaceID), "workspace_id configuration is required for OUTBOUND private connections. Without workspace_id, the request is treated as a DDL private connection."},
 	}
 }
 

--- a/internal/provider/privateconnections/privateconnectionvalidator_test.go
+++ b/internal/provider/privateconnections/privateconnectionvalidator_test.go
@@ -66,6 +66,12 @@ func TestValidatePrivateConnection(t *testing.T) {
 	plan.ServiceName = types.StringValue("test service name")
 
 	err = privateconnections.ValidatePrivateConnection(plan, false)
+	require.NotNil(t, err)
+	require.Equal(t, "workspace_id configuration is required for OUTBOUND private connections. Without workspace_id, the request is treated as a DDL private connection.", err.Detail)
+
+	plan.WorkspaceID = types.StringValue("41c1c310-9a5f-4a7a-ba8e-088af6056d8d")
+
+	err = privateconnections.ValidatePrivateConnection(plan, false)
 	require.Nil(t, err)
 
 	plan.AllowList = types.StringValue("12345")

--- a/internal/provider/privateconnections/resource.go
+++ b/internal/provider/privateconnections/resource.go
@@ -151,7 +151,7 @@ func (r *privateConnectionResource) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"workspace_id": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "The ID of the workspace to connect with.",
+				MarkdownDescription: "The ID of the workspace to connect with. Required for OUTBOUND private connections (DML private link).",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When creating an OUTBOUND `singlestoredb_private_connection` without `workspace_id`, the Management API treats the request as a DDL private link. If DDL private connections are not enabled for the account, the API returns an opaque internal server error (e.g. "DDL private connections are not...").

This change validates that `workspace_id` is set for OUTBOUND connections and returns a clear Terraform error at apply time instead.

## Changes

- Require `workspace_id` in outbound private connection validation
- Document that `workspace_id` is required for OUTBOUND (DML private link) in the resource schema and docs
- Add unit test coverage for the new validation rule

## Example error (after)

```
Error: Failed to validate private connection configuration

workspace_id configuration is required for OUTBOUND private connections. Without workspace_id, the request is treated as a DDL private connection.
```

## Testing

- `go test ./internal/provider/privateconnections/... -run TestValidatePrivateConnection`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08a51ff9-e20a-4773-ad57-a5fc46f4b875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08a51ff9-e20a-4773-ad57-a5fc46f4b875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

